### PR TITLE
Static build pipeline + Pages CI (gwern-style SSG)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+# A PR merge to main is a push to main — that triggers the build + deploy.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Let one deploy finish before the next starts (don't cancel an in-flight publish).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+_public/
+.DS_Store
+*.log

--- a/dev/_globals.mjs
+++ b/dev/_globals.mjs
@@ -1,0 +1,5 @@
+/** Browser-glue entry. esbuild bundles this (+ its imports) into _public/dev/globals.js as an IIFE,
+    exposing the pure block/render functions as window globals for the (Babel-compiled) plain view. */
+import { devBlocks } from "./blocks.mjs";
+import { toMarkdown, pmText, pmHref } from "../shared/render.mjs";
+Object.assign(window, { devBlocks, toMarkdown, pmText, pmHref });

--- a/dev/app.jsx
+++ b/dev/app.jsx
@@ -48,46 +48,8 @@ function HomeLayouts({ layout, posts, repos, stats, langs, byYear, onMore }) {
   );
 }
 
-/** Describe the current dev page as plain/markdown blocks. */
-function devBlocks({ route, posts, repos, stats, current }) {
-  if (route === "article" && current) {
-    return [
-      { t: "h1", text: current.title },
-      { t: "p", text: [current.dateLong || current.date, (current.tags || []).join(", ")].filter(Boolean).join(" · ") },
-      { t: "rawmd", md: "_Open this post on the site for the full text._" },
-    ];
-  }
-  if (route === "writing") {
-    return [
-      { t: "h1", text: "arslan.dev — writing" },
-      { t: "table", head: ["post", "date", "tags"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date, (p.tags || []).join(", ")]) },
-    ];
-  }
-  const RP = window.RP || {}, books = RP.books || [], games = RP.games || {}, now = games.now || {};
-  const b = [
-    { t: "h1", text: "arslan.dev" },
-    { t: "p", text: (window.DH && window.DH.tagline) || "" },
-    { t: "h2", text: "On GitHub" },
-    // 4 stat tiles across, like the rich row.
-    { t: "grid", cols: 4, cells: (stats || []).map(s => ({ title: s.num, lines: [s.ico, s.cap] })) },
-    { t: "h2", text: "Pinned repos" },
-    // 3-up grid of repo tiles, like the rich grid.
-    { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : [])] })) },
-  ];
-  if (posts.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["post", "date"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date]) });
-  const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);
-  b.push(
-    { t: "h2", text: "Reading & playing" },
-    // reading | playing, two columns side-by-side like the rich view.
-    { t: "grid", cols: 2, cells: [
-      { title: "Reading", lines: books.map(bk => `${bk.ti} — ${bk.au}`) },
-      { title: "Now playing", lines: playLines },
-    ] },
-    { t: "links", items: [{ label: "project catalog ↗", href: "../portfolio/" }, { label: "the personal side →", href: "../personal/" }] }
-  );
-  return b;
-}
-
+/** Plain/markdown blocks come from dev/blocks.mjs (window.devBlocks, set by globals.js) — one source
+    of truth shared with the Node static build. */
 function App() {
   const [route, setRoute] = useState("home");
   const [layout, setLayout] = useState("terminal");
@@ -154,7 +116,7 @@ function App() {
   };
 
   const current = slug ? posts.find(p => p.slug === slug) : null;
-  const buildBlocks = () => devBlocks({ route, posts, repos, stats, current });
+  const buildBlocks = () => window.devBlocks({ route, posts, repos, stats, current, dh: window.DH, rp: window.RP });
 
   if (plain) return (
     <>

--- a/dev/blocks.mjs
+++ b/dev/blocks.mjs
@@ -1,0 +1,41 @@
+/** Dev-side page -> block IR. Pure: takes all data as params (no window globals), so it runs in
+    Node (the static build) and the browser (bundled into globals.js). Consumed by the React plain
+    view (via window.devBlocks) and by scripts/build.mjs (imported directly). */
+export function devBlocks({ route, posts = [], repos = [], stats = [], current, dh = {}, rp = {} } = {}) {
+  if (route === "article" && current) {
+    return [
+      { t: "h1", text: current.title },
+      { t: "p", text: [current.dateLong || current.date, (current.tags || []).join(", ")].filter(Boolean).join(" · ") },
+      { t: "rawmd", md: "_Open this post on the site for the full text._" },
+    ];
+  }
+  if (route === "writing") {
+    return [
+      { t: "h1", text: "arslan.dev — writing" },
+      { t: "table", head: ["post", "date", "tags"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date, (p.tags || []).join(", ")]) },
+    ];
+  }
+  const books = rp.books || [], games = rp.games || {}, now = games.now || {};
+  const b = [
+    { t: "h1", text: "arslan.dev" },
+    { t: "p", text: dh.tagline || "" },
+    { t: "h2", text: "On GitHub" },
+    // 4 stat tiles across, like the rich row.
+    { t: "grid", cols: 4, cells: (stats || []).map(s => ({ title: s.num, lines: [s.ico, s.cap] })) },
+    { t: "h2", text: "Pinned repos" },
+    // 3-up grid of repo tiles, like the rich grid.
+    { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : [])] })) },
+  ];
+  if (posts.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["post", "date"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date]) });
+  const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);
+  b.push(
+    { t: "h2", text: "Reading & playing" },
+    // reading | playing, two columns side-by-side like the rich view.
+    { t: "grid", cols: 2, cells: [
+      { title: "Reading", lines: books.map(bk => `${bk.ti} — ${bk.au}`) },
+      { title: "Now playing", lines: playLines },
+    ] },
+    { t: "links", items: [{ label: "project catalog ↗", href: "../portfolio/" }, { label: "the personal side →", href: "../personal/" }] }
+  );
+  return b;
+}

--- a/dev/index.html
+++ b/dev/index.html
@@ -17,6 +17,8 @@
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+  <!-- Pure block/render functions (built from blocks.mjs + ../shared/render.mjs by esbuild). -->
+  <script src="globals.js"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,513 @@
+{
+  "name": "arslankazmi-github-io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "arslankazmi-github-io",
+      "version": "1.0.0",
+      "devDependencies": {
+        "esbuild": "^0.28.0",
+        "marked": "^18.0.5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "arslankazmi-github-io",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "index": "node scripts/build-index.mjs",
+    "build": "node scripts/build.mjs",
+    "serve": "python3 -m http.server --directory _public 8080"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.0",
+    "marked": "^18.0.5"
+  }
+}

--- a/personal/_globals.mjs
+++ b/personal/_globals.mjs
@@ -1,0 +1,5 @@
+/** Browser-glue entry. esbuild bundles this (+ its imports) into _public/personal/globals.js as an
+    IIFE, exposing the pure block/render functions as window globals for the (Babel-compiled) plain view. */
+import { personalBlocks } from "./blocks.mjs";
+import { toMarkdown, pmText, pmHref } from "../shared/render.mjs";
+Object.assign(window, { personalBlocks, toMarkdown, pmText, pmHref });

--- a/personal/app.jsx
+++ b/personal/app.jsx
@@ -1,51 +1,8 @@
 /** Personal-site root — state router over posts.json (personal side) + plain view. */
 const { useState, useEffect } = React;
 
-/** Describe the current personal page as plain/markdown blocks. */
-function personalBlocks({ route, entries, current }) {
-  if (route === "article" && current) {
-    return [
-      { t: "h1", text: current.title },
-      { t: "p", text: [current.dateLong || current.date, current.read, current.tag].filter(Boolean).join(" · ") },
-      ...(current.blurb ? [{ t: "p", text: current.blurb }] : []),
-      { t: "rawmd", md: "_Open this piece on the site for the full text._" },
-    ];
-  }
-  if (route === "about") {
-    return [
-      { t: "h1", text: "About" },
-      { t: "p", text: "I grew up on a quieter internet, made of forums and webrings and ugly, honest websites. This site is my attempt to keep a piece of that internet alive, even if only as a room of my own." },
-      { t: "p", text: "I'm happiest in the half-hour after sunset, in a city I don't know yet, with a book I haven't started." },
-      { t: "table", head: ["", ""], rows: [["Now", "nowhere"], ["Email", { text: "akazmi.public@gmail.com", href: "mailto:akazmi.public@gmail.com" }]] },
-    ];
-  }
-  if (route === "writing" || route === "notebook") {
-    const list = route === "notebook" ? entries.filter(e => (e.tags || []).some(t => t === "notebook" || t === "music")) : entries;
-    return [
-      { t: "h1", text: `arslan.land — ${route}` },
-      { t: "table", head: ["piece", "date", "tag"], rows: list.map(e => [{ text: e.title, href: `#/p/${e.slug}` }, e.date, e.tag || ""]) },
-    ];
-  }
-  const RP = window.RP || {}, books = RP.books || [], games = RP.games || {}, now = games.now || {};
-  const projects = window.AK.PROJECTS || [];
-  const b = [
-    { t: "h1", text: "arslan.land" },
-    { t: "p", text: "I make things on the internet and write about why. A small site for essays, notes, and the occasional weeknote." },
-  ];
-  if (entries.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["piece", "date", "tag"], rows: entries.map(e => [{ text: e.title, href: `#/p/${e.slug}` }, e.date, e.tag || ""]) });
-  if (projects.length) b.push({ t: "h2", text: "Projects" }, { t: "grid", cols: 3, cells: projects.map(p => ({ title: p.title, lines: [p.blurb] })) });
-  const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);
-  b.push(
-    { t: "h2", text: "Reading & playing" },
-    { t: "grid", cols: 2, cells: [
-      { title: "Reading", lines: books.map(bk => `${bk.ti} — ${bk.au}`) },
-      { title: "Now playing", lines: playLines },
-    ] },
-    { t: "links", items: [{ label: "the dev side →", href: "../dev/" }] }
-  );
-  return b;
-}
-
+/** Plain/markdown blocks come from personal/blocks.mjs (window.personalBlocks, set by globals.js) —
+    one source of truth shared with the Node static build. */
 function App() {
   const [route, setRoute] = useState("home");
   const [slug, setSlug] = useState(null);
@@ -76,7 +33,7 @@ function App() {
 
   const notebookEntries = entries.filter(e => (e.tags || []).some(t => t === "notebook" || t === "music"));
   const current = slug ? entries.find(e => e.slug === slug) : null;
-  const buildBlocks = () => personalBlocks({ route, entries, current });
+  const buildBlocks = () => window.personalBlocks({ route, entries, current, rp: window.RP, projects: (window.AK || {}).PROJECTS || [] });
 
   if (plain) return (
     <>

--- a/personal/blocks.mjs
+++ b/personal/blocks.mjs
@@ -1,0 +1,45 @@
+/** Personal-side page -> block IR. Pure: takes all data as params (no window globals), so it runs in
+    Node (the static build) and the browser (bundled into globals.js). Consumed by the React plain
+    view (via window.personalBlocks) and by scripts/build.mjs (imported directly). */
+export function personalBlocks({ route, entries = [], current, rp = {}, projects = [] } = {}) {
+  if (route === "article" && current) {
+    return [
+      { t: "h1", text: current.title },
+      { t: "p", text: [current.dateLong || current.date, current.read, current.tag].filter(Boolean).join(" · ") },
+      ...(current.blurb ? [{ t: "p", text: current.blurb }] : []),
+      { t: "rawmd", md: "_Open this piece on the site for the full text._" },
+    ];
+  }
+  if (route === "about") {
+    return [
+      { t: "h1", text: "About" },
+      { t: "p", text: "I grew up on a quieter internet, made of forums and webrings and ugly, honest websites. This site is my attempt to keep a piece of that internet alive, even if only as a room of my own." },
+      { t: "p", text: "I'm happiest in the half-hour after sunset, in a city I don't know yet, with a book I haven't started." },
+      { t: "table", head: ["", ""], rows: [["Now", "nowhere"], ["Email", { text: "akazmi.public@gmail.com", href: "mailto:akazmi.public@gmail.com" }]] },
+    ];
+  }
+  if (route === "writing" || route === "notebook") {
+    const list = route === "notebook" ? entries.filter(e => (e.tags || []).some(t => t === "notebook" || t === "music")) : entries;
+    return [
+      { t: "h1", text: `arslan.land — ${route}` },
+      { t: "table", head: ["piece", "date", "tag"], rows: list.map(e => [{ text: e.title, href: `#/p/${e.slug}` }, e.date, e.tag || ""]) },
+    ];
+  }
+  const books = rp.books || [], games = rp.games || {}, now = games.now || {};
+  const b = [
+    { t: "h1", text: "arslan.land" },
+    { t: "p", text: "I make things on the internet and write about why. A small site for essays, notes, and the occasional weeknote." },
+  ];
+  if (entries.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["piece", "date", "tag"], rows: entries.map(e => [{ text: e.title, href: `#/p/${e.slug}` }, e.date, e.tag || ""]) });
+  if (projects.length) b.push({ t: "h2", text: "Projects" }, { t: "grid", cols: 3, cells: projects.map(p => ({ title: p.title, lines: [p.blurb] })) });
+  const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);
+  b.push(
+    { t: "h2", text: "Reading & playing" },
+    { t: "grid", cols: 2, cells: [
+      { title: "Reading", lines: books.map(bk => `${bk.ti} — ${bk.au}`) },
+      { title: "Now playing", lines: playLines },
+    ] },
+    { t: "links", items: [{ label: "the dev side →", href: "../dev/" }] }
+  );
+  return b;
+}

--- a/personal/index.html
+++ b/personal/index.html
@@ -17,6 +17,8 @@
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+  <!-- Pure block/render functions (built from blocks.mjs + ../shared/render.mjs by esbuild). -->
+  <script src="globals.js"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -6,15 +6,15 @@
    No dependencies (Node 18+). Run: `node scripts/build-index.mjs`.
    ============================================================ */
 import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const repo = join(here, "..");
+const REPO = join(here, "..");
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 function parseFront(raw) {
-  const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*/);
+  const m = raw.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*/);
   const fm = {};
   if (!m) return fm;
   for (const line of m[1].split("\n")) {
@@ -34,7 +34,7 @@ function parseFront(raw) {
 const short = (iso) => { const [y, mo] = iso.split("-"); return `${MONTHS[+mo - 1]} ${y}`; };
 const long = (iso) => { const [y, mo, d] = iso.split("-"); return `${MONTHS[+mo - 1]} ${+d}, ${y}`; };
 
-function collect(side) {
+function collect(repo, side) {
   const dir = join(repo, "posts", side);
   if (!existsSync(dir)) return [];
   return readdirSync(dir)
@@ -59,6 +59,14 @@ function collect(side) {
     .sort((a, b) => (a.iso < b.iso ? 1 : -1));
 }
 
-const out = { dev: collect("dev"), personal: collect("personal") };
-writeFileSync(join(repo, "posts.json"), JSON.stringify(out, null, 2) + "\n");
-console.log(`posts.json — ${out.dev.length} dev, ${out.personal.length} personal`);
+/** Scan posts/{dev,personal}/*.md under `repo` and return { dev:[…], personal:[…] }. */
+export function buildIndex(repo = REPO) {
+  return { dev: collect(repo, "dev"), personal: collect(repo, "personal") };
+}
+
+// CLI: write posts.json to the repo root.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const out = buildIndex(REPO);
+  writeFileSync(join(REPO, "posts.json"), JSON.stringify(out, null, 2) + "\n");
+  console.log(`posts.json — ${out.dev.length} dev, ${out.personal.length} personal`);
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/* ============================================================
+   build.mjs — compile the site into _public/ (gwern-style static rendering).
+
+   What it does, in order:
+     1. Build posts.json (the post index).
+     2. Snapshot build-time data: portfolio repos + live GitHub stats (with fallbacks).
+     3. Copy the served tree into _public/ (assets, css, jsx, posts, html); drop build-only *.mjs.
+     4. esbuild-bundle the pure block/render modules into per-page globals.js (IIFE) for the browser.
+     5. Inject a self-contained, 1999-renderable PLAIN baseline into each shell's <noscript> so the
+        site is fully readable with JavaScript disabled; React enhances to the rich view when JS runs.
+     6. Render every post to a standalone static HTML page at /<side>/p/<slug>/ (real, crawlable URLs).
+
+   Pure block logic is shared with the browser via shared/render.mjs + {dev,personal}/blocks.mjs —
+   one source of truth, no drift. Node 18+ (global fetch). Run: `node scripts/build.mjs`.
+   ============================================================ */
+import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, existsSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+import { marked } from "marked";
+import * as esbuild from "esbuild";
+import { buildIndex } from "./build-index.mjs";
+import { devBlocks } from "../dev/blocks.mjs";
+import { personalBlocks } from "../personal/blocks.mjs";
+import { toStaticHTML, he } from "../shared/render.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, "..");
+const OUT = join(REPO, "_public");
+const USER = "arslankazmi";
+const PROJECTS_URL = "https://arslankazmi.github.io/portfolio/data/projects.json";
+
+const log = (...a) => console.log("[build]", ...a);
+
+/** Evaluate a browser data file (which assigns window.X = …) and return the populated window. */
+function loadWindowGlobals(file) {
+  try {
+    const code = readFileSync(file, "utf8");
+    const fn = new Function("window", code + "\n;return window;");
+    return fn({});
+  } catch (e) {
+    log(`warn: could not load globals from ${relative(REPO, file)}: ${e.message}`);
+    return {};
+  }
+}
+
+/** Recursively delete files matching a predicate under dir. */
+function pruneFiles(dir, pred) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) pruneFiles(p, pred);
+    else if (pred(p)) rmSync(p);
+  }
+}
+
+/** Build-time data snapshot for the dev hub (repos + GitHub stats), with graceful fallbacks. */
+async function devSnapshot(dh) {
+  let repos = [];
+  try {
+    const d = await (await fetch(PROJECTS_URL)).json();
+    repos = (d.projects || []).map(p => ({
+      name: p.name, desc: p.description || "", lang: p.language || "", url: p.repo, docs: p.docs || "",
+    }));
+  } catch (e) { log("repos fetch failed, baseline omits pinned repos:", e.message); }
+
+  let stats = dh.stats || [];
+  try {
+    const [user, repoList] = await Promise.all([
+      fetch(`https://api.github.com/users/${USER}`).then(r => r.ok ? r.json() : null),
+      fetch(`https://api.github.com/users/${USER}/repos?per_page=100&type=owner`).then(r => r.ok ? r.json() : null),
+    ]);
+    if (user && Array.isArray(repoList)) {
+      const owned = repoList.filter(r => !r.fork);
+      const stars = owned.reduce((s, r) => s + (r.stargazers_count || 0), 0);
+      const est = new Date(user.created_at).getFullYear();
+      const years = new Date().getFullYear() - est;
+      stats = [
+        { ico: "◆ repos", num: String(user.public_repos), cap: "public" },
+        { ico: "✦ stars", num: String(stars), cap: "across repos" },
+        { ico: "❂ followers", num: String(user.followers), cap: "on github" },
+        { ico: "⌁ since", num: `${years}y`, cap: `est. ${est}` },
+      ];
+    }
+  } catch (e) { log("github stats fetch failed, baseline uses sample stats:", e.message); }
+  return { repos, stats };
+}
+
+/** Wrap a block-IR render into a no-JS <noscript> plain baseline, with self-contained styling and
+    post links rewritten from SPA hash routes (#/p/slug) to the real static page URLs (p/slug/). */
+function noscriptBaseline(blocks, nav) {
+  const body = toStaticHTML(blocks, (md) => marked.parse(md)).replace(/href="#\/p\/([^"]+)"/g, (_, slug) => `href="p/${slug}/"`);
+  return `<noscript>
+  <style>
+    html[data-theme], html[data-view], body { background:#fff !important; background-image:none !important; color:#111 !important; }
+    .ssg-plain { max-width:860px; margin:0 auto; padding:30px 20px 90px; font-family:Georgia,"Times New Roman",Times,serif; line-height:1.55; }
+    .ssg-plain a { color:#0645ad; }
+    .ssg-plain h1 { font-size:2rem; line-height:1.15; margin:0 0 .25rem; }
+    .ssg-plain h2 { font-size:1.3rem; margin:1.7rem 0 .5rem; border-bottom:1px solid #e2e2e2; padding-bottom:3px; }
+    .ssg-plain p { margin:.5rem 0; }
+    .ssg-plain .pm-nav { font-family:monospace; font-size:.82rem; color:#555; margin-bottom:1.2rem; }
+    .ssg-plain table { border-collapse:collapse; width:100%; margin:.5rem 0 1.1rem; font-size:.92rem; }
+    .ssg-plain th, .ssg-plain td { border:1px solid #dcdcdc; padding:5px 10px; text-align:left; vertical-align:top; }
+    .ssg-plain th { background:#f3f3f1; }
+  </style>
+  <div class="ssg-plain">
+    <p class="pm-nav">${nav}</p>
+    ${body}
+  </div>
+</noscript>`;
+}
+
+/** Read a shell index.html, add the no-JS baseline right after <div id="root"></div>, write to OUT. */
+function emitShell(srcRel, blocks, nav) {
+  const html = readFileSync(join(REPO, srcRel), "utf8");
+  const injected = html.replace(/<div id="root"><\/div>/, `<div id="root"></div>\n  ${noscriptBaseline(blocks, nav)}`);
+  if (injected === html) throw new Error(`could not inject baseline into ${srcRel} (no <div id="root"></div>)`);
+  writeFileSync(join(OUT, srcRel), injected);
+  log("shell +baseline:", srcRel);
+}
+
+/** Standalone static page for a single post. */
+function postPage(side, post, bodyHtml) {
+  const theme = side === "dev" ? ` data-theme="dark"` : "";
+  const css = side === "dev"
+    ? "https://arslankazmi.github.io/ak-design/dist/dev.css"
+    : "https://arslankazmi.github.io/ak-design/dist/personal.css";
+  const site = side === "dev" ? "arslan.dev" : "arslan.land";
+  const meta = he([post.dateLong || post.date, (post.tags || []).join(", ")].filter(Boolean).join(" · "));
+  return `<!doctype html>
+<html lang="en"${theme}>
+<head>
+  <meta charset="utf-8"/>
+  <title>${he(post.title)} · ${site}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  ${post.blurb ? `<meta name="description" content="${he(post.blurb)}"/>` : ""}
+  <link rel="icon" type="image/svg+xml" href="../../../assets/favicon.svg"/>
+  <link rel="stylesheet" href="${css}"/>
+  <style>
+    .post { max-width: 42rem; margin: 0 auto; padding: 56px 20px 96px; }
+    .post .meta { font-family: var(--font-mono, monospace); font-size: 13px; opacity: .7; margin-bottom: 10px; }
+    .post h1 { font-family: var(--font-display, Georgia, serif); line-height: 1.12; margin: 0 0 28px; }
+    .post .prose { line-height: 1.7; font-size: 1.05rem; }
+    .post .prose h2, .post .prose h3 { font-family: var(--font-display, Georgia, serif); margin-top: 1.6em; }
+    .post .prose pre { overflow:auto; padding:14px; border-radius:8px; background:rgba(127,127,127,.12); }
+    .post img { max-width: 100%; height: auto; }
+    .post .back { font-family: var(--font-mono, monospace); font-size: 13px; display:inline-block; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <main class="post">
+    <div class="meta">${meta}</div>
+    <h1>${he(post.title)}</h1>
+    <div class="prose">${bodyHtml}</div>
+    <a class="back" href="../../">← all writing</a>
+  </main>
+</body>
+</html>
+`;
+}
+
+async function main() {
+  // 1. index
+  const index = buildIndex(REPO);
+  rmSync(OUT, { recursive: true, force: true });
+  mkdirSync(OUT, { recursive: true });
+  writeFileSync(join(OUT, "posts.json"), JSON.stringify(index, null, 2) + "\n");
+  log(`index: ${index.dev.length} dev, ${index.personal.length} personal posts`);
+
+  // 2. data + snapshot
+  const DH = loadWindowGlobals(join(REPO, "dev/data.js")).DH || {};
+  const RP = loadWindowGlobals(join(REPO, "shared/reading-data.js")).RP || {};
+  const AK = loadWindowGlobals(join(REPO, "personal/data.js")).AK || {};
+  const { repos, stats } = await devSnapshot(DH);
+  log(`snapshot: ${repos.length} repos, ${stats.length} stat tiles`);
+
+  // 3. copy served tree
+  for (const item of ["assets", "shared", "dev", "personal", "posts"]) {
+    if (existsSync(join(REPO, item))) cpSync(join(REPO, item), join(OUT, item), { recursive: true });
+  }
+  for (const f of ["index.html", ".nojekyll"]) {
+    if (existsSync(join(REPO, f))) cpSync(join(REPO, f), join(OUT, f));
+  }
+  if (!existsSync(join(OUT, ".nojekyll"))) writeFileSync(join(OUT, ".nojekyll"), "");
+  // drop build-only modules from the published tree
+  pruneFiles(OUT, (p) => p.endsWith(".mjs"));
+
+  // 4. esbuild the browser glue (pure block/render fns -> window globals)
+  for (const side of ["dev", "personal"]) {
+    await esbuild.build({
+      entryPoints: [join(REPO, side, "_globals.mjs")],
+      bundle: true, format: "iife", minify: true,
+      outfile: join(OUT, side, "globals.js"),
+    });
+    log(`globals.js: ${side}`);
+  }
+
+  // 5. no-JS plain baselines injected into the shells
+  const devNav = `<a href="./">home</a> · <a href="../portfolio/">projects</a> · <a href="../personal/">arslan.land</a>`;
+  emitShell("dev/index.html",
+    devBlocks({ route: "home", posts: index.dev, repos, stats, dh: DH, rp: RP }), devNav);
+
+  const personalEntries = (index.personal || []).map(p => ({ ...p, tag: (p.tags || [])[0] || p.tag || "" }));
+  // No-JS nav: home lists the writing entries already (as real p/<slug>/ links), so no dead hash link.
+  const personalNav = `<a href="./">home</a> · <a href="../dev/">arslan.dev</a>`;
+  emitShell("personal/index.html",
+    personalBlocks({ route: "home", entries: personalEntries, rp: RP, projects: AK.PROJECTS || [] }), personalNav);
+
+  // 6. per-post static pages
+  let postCount = 0;
+  for (const side of ["dev", "personal"]) {
+    for (const post of index[side] || []) {
+      const raw = readFileSync(join(REPO, post.path), "utf8").replace(/^---[\s\S]*?\r?\n---\r?\n?\s*/, "");
+      const dir = join(OUT, side, "p", post.slug);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "index.html"), postPage(side, post, marked.parse(raw)));
+      postCount++;
+    }
+  }
+  log(`per-post pages: ${postCount}`);
+  log(`done -> ${relative(REPO, OUT)}/`);
+}
+
+main().catch((e) => { console.error("[build] FAILED:", e); process.exit(1); });

--- a/shared/plain.jsx
+++ b/shared/plain.jsx
@@ -1,55 +1,8 @@
-/** Shared plain/markdown engine. A page is an ordered list of "blocks"; the same list renders two
-    ways: a self-contained, presentational HTML "plain" replica (renders in a 1999 browser — borders
-    via table ATTRIBUTES, no modern CSS needed), and a Markdown string. Block types:
-      h1 h2 p hr links rawmd · table {head, rows} (vertical list) · grid {cols, cells} (mirrors the
-      rich view's columnar/tiled layout — stat tiles, repo/project tiles, reading|playing side-by-side).
-    A grid cell is { title?, href?, lines:[ string | {text, href} ] }. */
+/** Shared plain-view React components. The pure block→HTML/Markdown logic lives in shared/render.mjs
+    (single source of truth, also used by the Node static build); esbuild exposes it on window via the
+    per-page globals.js (window.toMarkdown / pmText / pmHref). This file is only the React rendering of
+    the live in-app plain toggle + the copy-as-markdown button. Block types are documented in render.mjs. */
 const { useState: useStatePM } = React;
-
-function pmText(c) { return (c && typeof c === "object") ? (c.text ?? "") : (c == null ? "" : String(c)); }
-function pmHref(c) { return (c && typeof c === "object") ? (c.href || null) : null; }
-function mdEsc(s) { return String(s).replace(/\|/g, "\\|").replace(/\s*\n\s*/g, " ").trim(); }
-function mdCell(c) { const t = mdEsc(pmText(c)); const h = pmHref(c); return h ? `[${t}](${h})` : t; }
-function lineMd(ln) { return (ln && typeof ln === "object") ? `[${mdEsc(ln.text)}](${ln.href || ""})` : mdEsc(ln); }
-function gridCellMd(c) {
-  const parts = [];
-  if (c.title) parts.push(c.href ? `**[${mdEsc(c.title)}](${c.href})**` : `**${mdEsc(c.title)}**`);
-  for (const ln of (c.lines || [])) { const m = lineMd(ln); if (m) parts.push(m); }
-  return parts.join("<br>");
-}
-
-/** blocks → Markdown (tables/grids preserved as Markdown tables). */
-function toMarkdown(blocks) {
-  const out = [];
-  for (const b of (blocks || [])) {
-    if (b.t === "h1") out.push(`# ${b.text}`);
-    else if (b.t === "h2") out.push(`## ${b.text}`);
-    else if (b.t === "p") out.push(b.text);
-    else if (b.t === "hr") out.push("---");
-    else if (b.t === "rawmd") out.push((b.md || "").trim());
-    else if (b.t === "links") out.push((b.items || []).map(i => `[${mdEsc(i.label)}](${i.href})`).join(" · "));
-    else if (b.t === "table") {
-      const head = b.head || [];
-      if (head.length) {
-        out.push(`| ${head.map(mdEsc).join(" | ")} |`);
-        out.push(`| ${head.map(() => "---").join(" | ")} |`);
-      }
-      for (const r of (b.rows || [])) out.push(`| ${r.map(mdCell).join(" | ")} |`);
-    } else if (b.t === "grid") {
-      const cols = b.cols || 2;
-      const cells = (b.cells || []).map(gridCellMd);
-      out.push(`| ${Array.from({ length: cols }, () => " ").join(" | ")} |`);
-      out.push(`| ${Array.from({ length: cols }, () => "---").join(" | ")} |`);
-      for (let i = 0; i < cells.length; i += cols) {
-        const row = cells.slice(i, i + cols);
-        while (row.length < cols) row.push(" ");
-        out.push(`| ${row.join(" | ")} |`);
-      }
-    }
-    out.push("");
-  }
-  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim() + "\n";
-}
 
 function GridCell({ c }) {
   return (
@@ -60,7 +13,8 @@ function GridCell({ c }) {
   );
 }
 
-/** blocks → React, as self-contained presentational HTML (table borders via attributes). */
+/** blocks → React, as self-contained presentational HTML (table borders via attributes). Mirrors
+    shared/render.mjs `toStaticHTML` exactly — keep the two in sync. */
 function PlainBlocks({ blocks }) {
   return (blocks || []).map((b, i) => {
     if (b.t === "h1") return <h1 key={i}>{b.text}</h1>;
@@ -72,7 +26,7 @@ function PlainBlocks({ blocks }) {
     if (b.t === "table") return (
       <table key={i} border="1" cellPadding="6" cellSpacing="0" width="100%">
         {b.head && b.head.length > 0 && <thead><tr>{b.head.map((h, j) => <th key={j} align="left" bgcolor="#f0f0f0">{h}</th>)}</tr></thead>}
-        <tbody>{(b.rows || []).map((r, ri) => <tr key={ri}>{r.map((c, ci) => <td key={ci} valign="top">{pmHref(c) ? <a href={pmHref(c)}>{pmText(c)}</a> : pmText(c)}</td>)}</tr>)}</tbody>
+        <tbody>{(b.rows || []).map((r, ri) => <tr key={ri}>{r.map((c, ci) => <td key={ci} valign="top">{window.pmHref(c) ? <a href={window.pmHref(c)}>{window.pmText(c)}</a> : window.pmText(c)}</td>)}</tr>)}</tbody>
       </table>
     );
     if (b.t === "grid") {
@@ -101,7 +55,7 @@ function PlainBlocks({ blocks }) {
 function CopyMarkdown({ getBlocks }) {
   const [done, setDone] = useStatePM(false);
   const copy = async () => {
-    const md = toMarkdown(getBlocks() || []);
+    const md = window.toMarkdown(getBlocks() || []);
     let ok = false;
     try { await navigator.clipboard.writeText(md); ok = true; } catch (_) {
       try {
@@ -115,4 +69,4 @@ function CopyMarkdown({ getBlocks }) {
   return <button className="md-copy" onClick={copy} title="Copy this page as Markdown">{done ? "✓ copied markdown" : "⧉ copy as markdown"}</button>;
 }
 
-Object.assign(window, { PlainBlocks, CopyMarkdown, toMarkdown });
+Object.assign(window, { PlainBlocks, CopyMarkdown });

--- a/shared/render.mjs
+++ b/shared/render.mjs
@@ -1,0 +1,108 @@
+/** Shared, pure block renderers — single source of truth for the plain/markdown/static backends.
+    A page is an ordered list of "blocks"; this module turns that list into either a Markdown string
+    or a self-contained, 1999-renderable HTML string. NO React, NO DOM, NO npm deps — so it runs
+    identically in Node (the build) and in the browser (bundled into globals.js by esbuild).
+
+    Block types: h1 h2 p hr links rawmd · table {head, rows} · grid {cols, cells}.
+    A grid cell is { title?, href?, lines:[ string | {text, href} ] }.
+    The React plain view (shared/plain.jsx) and the Node static build both consume these. */
+
+export function pmText(c) { return (c && typeof c === "object") ? (c.text ?? "") : (c == null ? "" : String(c)); }
+export function pmHref(c) { return (c && typeof c === "object") ? (c.href || null) : null; }
+
+export function mdEsc(s) { return String(s).replace(/\|/g, "\\|").replace(/\s*\n\s*/g, " ").trim(); }
+export function mdCell(c) { const t = mdEsc(pmText(c)); const h = pmHref(c); return h ? `[${t}](${h})` : t; }
+function lineMd(ln) { return (ln && typeof ln === "object") ? `[${mdEsc(ln.text)}](${ln.href || ""})` : mdEsc(ln); }
+function gridCellMd(c) {
+  const parts = [];
+  if (c.title) parts.push(c.href ? `**[${mdEsc(c.title)}](${c.href})**` : `**${mdEsc(c.title)}**`);
+  for (const ln of (c.lines || [])) { const m = lineMd(ln); if (m) parts.push(m); }
+  return parts.join("<br>");
+}
+
+/** blocks -> Markdown (tables/grids preserved as Markdown tables). */
+export function toMarkdown(blocks) {
+  const out = [];
+  for (const b of (blocks || [])) {
+    if (b.t === "h1") out.push(`# ${b.text}`);
+    else if (b.t === "h2") out.push(`## ${b.text}`);
+    else if (b.t === "p") out.push(b.text);
+    else if (b.t === "hr") out.push("---");
+    else if (b.t === "rawmd") out.push((b.md || "").trim());
+    else if (b.t === "links") out.push((b.items || []).map(i => `[${mdEsc(i.label)}](${i.href})`).join(" · "));
+    else if (b.t === "table") {
+      const head = b.head || [];
+      if (head.length) {
+        out.push(`| ${head.map(mdEsc).join(" | ")} |`);
+        out.push(`| ${head.map(() => "---").join(" | ")} |`);
+      }
+      for (const r of (b.rows || [])) out.push(`| ${r.map(mdCell).join(" | ")} |`);
+    } else if (b.t === "grid") {
+      const cols = b.cols || 2;
+      const cells = (b.cells || []).map(gridCellMd);
+      out.push(`| ${Array.from({ length: cols }, () => " ").join(" | ")} |`);
+      out.push(`| ${Array.from({ length: cols }, () => "---").join(" | ")} |`);
+      for (let i = 0; i < cells.length; i += cols) {
+        const row = cells.slice(i, i + cols);
+        while (row.length < cols) row.push(" ");
+        out.push(`| ${row.join(" | ")} |`);
+      }
+    }
+    out.push("");
+  }
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim() + "\n";
+}
+
+/** HTML-escape text node/attribute content (toMarkdown/React escape for us elsewhere; here we emit raw strings). */
+export function he(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+function anchor(text, href) { return `<a href="${he(href)}">${he(text)}</a>`; }
+function lineHtml(ln) {
+  if (ln && typeof ln === "object") return ln.href ? anchor(ln.text, ln.href) : he(ln.text);
+  return he(ln);
+}
+function gridCellHtml(c) {
+  let s = "";
+  if (c.title) s += `<div><b>${c.href ? anchor(c.title, c.href) : he(c.title)}</b></div>`;
+  for (const ln of (c.lines || [])) s += `<div>${lineHtml(ln)}</div>`;
+  return `<td valign="top">${s}</td>`;
+}
+
+/** blocks -> self-contained presentational HTML string (borders via table ATTRIBUTES; renders in a
+    1999 browser with no modern CSS). Mirrors the React PlainBlocks component exactly.
+    `renderMd` (optional) converts a rawmd block's markdown to HTML; defaults to escaping it. */
+export function toStaticHTML(blocks, renderMd) {
+  const md = typeof renderMd === "function" ? renderMd : (s) => he(s);
+  const out = [];
+  for (const b of (blocks || [])) {
+    if (b.t === "h1") out.push(`<h1>${he(b.text)}</h1>`);
+    else if (b.t === "h2") out.push(`<h2>${he(b.text)}</h2>`);
+    else if (b.t === "p") out.push(`<p>${he(b.text)}</p>`);
+    else if (b.t === "hr") out.push(`<hr>`);
+    else if (b.t === "rawmd") out.push(`<div class="pm-body">${md(b.md || "")}</div>`);
+    else if (b.t === "links") out.push(`<p class="pm-links">${(b.items || []).map(it => anchor(it.label, it.href)).join(" · ")}</p>`);
+    else if (b.t === "table") {
+      let s = `<table border="1" cellpadding="6" cellspacing="0" width="100%">`;
+      if (b.head && b.head.length) s += `<thead><tr>${b.head.map(h => `<th align="left" bgcolor="#f0f0f0">${he(h)}</th>`).join("")}</tr></thead>`;
+      s += `<tbody>${(b.rows || []).map(r => `<tr>${r.map(c => `<td valign="top">${pmHref(c) ? anchor(pmText(c), pmHref(c)) : he(pmText(c))}</td>`).join("")}</tr>`).join("")}</tbody></table>`;
+      out.push(s);
+    } else if (b.t === "grid") {
+      const cols = b.cols || 2;
+      const cells = b.cells || [];
+      const rows = [];
+      for (let j = 0; j < cells.length; j += cols) rows.push(cells.slice(j, j + cols));
+      let s = `<table border="1" cellpadding="6" cellspacing="0" width="100%"><tbody>`;
+      for (const row of rows) {
+        s += `<tr>${row.map(gridCellHtml).join("")}`;
+        for (let k = row.length; k < cols; k++) s += `<td></td>`;
+        s += `</tr>`;
+      }
+      s += `</tbody></table>`;
+      out.push(s);
+    }
+  }
+  return out.join("\n");
+}


### PR DESCRIPTION
## What

Adds a build step that compiles the site into `_public/` and deploys it to GitHub Pages on merge to `main`, while keeping the existing runtime React app. Modeled on gwern.net: static HTML at build time, progressive enhancement, fast loads.

## Highlights

- **No-JS / 1999 plain mode**: each shell ships a self-contained `<noscript>` plain baseline (presentational tables, build-time data baked in) — fully readable with JavaScript disabled. React enhances to the rich view when JS runs.
- **Real per-post pages**: every post renders to a standalone static HTML page at `/<side>/p/<slug>/` (crawlable URLs), in addition to the SPA hash routes.
- **Single source of truth**: the plain/markdown block IR lives in `shared/render.mjs` + `{dev,personal}/blocks.mjs` (pure ESM). Node imports them; the browser gets them as `window` globals via an esbuild IIFE (`globals.js`). No browser/Node drift.
- **Build-time data**: portfolio repos + live GitHub stats are snapshotted into the static baseline (rich view still re-fetches live).

## Verified

- Rich view (dev + personal) boots correctly with the new globals wiring; live stats render.
- Plain toggle (both sides) works through `window.devBlocks`/`personalBlocks`.
- No-JS baseline (both sides) renders as readable static HTML.
- Per-post pages escape title/blurb/meta; markdown body renders.

## One-time setup required

Switch **Settings → Pages → Source** to **GitHub Actions** before/at merge — otherwise `deploy-pages` has nothing to publish to. `_public/` is ephemeral build output (gitignored), not committed.

## Deferred (documented follow-up)

Bundling the JSX with esbuild to drop the in-browser `@babel/standalone` (~3 MB). The static baseline already delivers content-first paint, so this is a perf nicety, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)