### PR TITLE
Phase 2: margin sidenotes + build-time link/doc/image previews

### DIFF
--- a/ASSET_CREDITS.md
+++ b/ASSET_CREDITS.md
@@ -1,5 +1,20 @@
 # Asset credits
 
+> Site-wide acknowledgements & inspirations (gwern.net, Tufte, libraries) live on the
+> [`/acknowledgements/`](acknowledgements/index.html) page. This file is the per-asset / per-code license detail.
+
+## Code & patterns
+
+- **Sidenotes** (`shared/sidenotes.{js,css}`) — the margin-note behaviour reuses the *pattern* of
+  [gwern.net's `sidenotes.js`](https://gwern.net/static/js/sidenotes.js) (Said Achmiz, MIT), which itself
+  builds on [Tufte-CSS](https://edwardtufte.github.io/tufte-css/#sidenotes). Reimplemented self-contained
+  (gwern's file is coupled to its larger site engine); not a copy of the source.
+- **Link/document previews** (`scripts/annotations.mjs`, `shared/previews.{js,css}`) — UX inspired by
+  gwern's popups (`popups.js` / `extracts.js`); implementation is original.
+- **`marked-footnote`** (MIT) — Markdown footnote extension, used in the build and in-browser.
+
+## Assets
+
 - **`assets/metroid-prime.png`** — Metroid Prime logo. © Nintendo; in the **public domain**
   (below the threshold of originality — text logo), via
   [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Metroid-Prime-Logo.png).

--- a/acknowledgements/index.html
+++ b/acknowledgements/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Acknowledgements & Inspirations · arslan</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="description" content="The people, projects, and ideas this site borrows from — with thanks. Sidenotes and link-preview UX after gwern.net; sidenotes pattern after Tufte."/>
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg"/>
+  <!-- Paper theme for a colophon feel. -->
+  <link rel="stylesheet" href="https://arslankazmi.github.io/ak-design/dist/personal.css"/>
+  <style>
+    .ack { max-width: 44rem; margin: 0 auto; padding: 64px 22px 110px; line-height: 1.62; }
+    .ack .kicker { font-family: var(--font-mono, monospace); font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; opacity: 0.65; }
+    .ack h1 { font-family: var(--font-display, Georgia, serif); line-height: 1.1; margin: 0.2em 0 0.5em; }
+    .ack .lede { font-size: 1.12rem; opacity: 0.9; }
+    .ack h2 { font-family: var(--font-display, Georgia, serif); margin: 2.2rem 0 0.4rem; }
+    .ack h3 { margin: 1.4rem 0 0.2rem; font-size: 1.02rem; }
+    .ack ul { padding-left: 1.1rem; }
+    .ack li { margin: 0.35rem 0; }
+    .ack .note { font-size: 0.92rem; opacity: 0.75; }
+    .ack a { color: var(--accent, #178e8b); }
+    .ack hr { border: 0; border-top: 1px solid var(--border, rgba(0,0,0,0.12)); margin: 2.4rem 0; }
+    .ack .back { font-family: var(--font-mono, monospace); font-size: 13px; }
+  </style>
+</head>
+<body>
+  <main class="ack">
+    <p class="kicker">Colophon</p>
+    <h1>Acknowledgements &amp; inspirations</h1>
+    <p class="lede">This site is built on other people's good ideas and good code. Where something was
+      borrowed, adapted, or learned from, it's named here — and, where it matters, in the piece that uses it.</p>
+
+    <h2><a href="https://gwern.net/design">gwern.net</a> — Gwern Branwen (&amp; Said Achmiz)</h2>
+    <p>The largest influence by far. The reading experience here is an homage to gwern.net's:</p>
+    <ul>
+      <li><strong>Sidenotes.</strong> The margin-note behaviour follows
+        <a href="https://gwern.net/static/js/sidenotes.js">gwern's <code>sidenotes.js</code></a>
+        (by Said Achmiz, MIT). gwern's file is coupled to its larger site engine, so this site reuses the
+        <em>pattern</em> — a small self-contained reimplementation — rather than the file itself. Demonstrated in
+        <a href="/dev/p/sidenotes-and-previews/">“Sidenotes, previews, and other quiet machinery”</a>.</li>
+      <li><strong>Link / document previews.</strong> The hover-preview cards are inspired by gwern's
+        <a href="https://gwern.net/design#popups">popups</a> (<code>popups.js</code> / <code>extracts.js</code>):
+        annotations compiled at build time, shown on hover. This implementation is custom.</li>
+      <li><strong>The whole philosophy</strong> — static HTML rendered at build time, aggressive
+        <a href="https://gwern.net/design#abstract">progressive enhancement</a> (the site is fully readable with
+        JavaScript off), speed, and a “semantic zoom” approach to links.</li>
+      <li><strong><a href="https://gwern.net/gwtar">gwtar</a></strong> — gwern's single-file self-extracting HTML
+        archive format, on the roadmap here for link archiving.</li>
+    </ul>
+
+    <h2>Sidenotes lineage</h2>
+    <ul>
+      <li><a href="https://edwardtufte.github.io/tufte-css/#sidenotes">Tufte-CSS</a> / <strong>Edward Tufte</strong>
+        — sidenotes as a form originate here; gwern's version (and therefore this one) build on it.</li>
+    </ul>
+
+    <h2>Tools &amp; libraries</h2>
+    <ul>
+      <li><a href="https://marked.js.org/">marked</a> + <a href="https://github.com/bent10/marked-extensions/tree/main/packages/footnote">marked-footnote</a> — Markdown → HTML, and footnotes.</li>
+      <li><a href="https://esbuild.github.io/">esbuild</a> — fast bundling of the browser glue.</li>
+      <li><a href="https://react.dev/">React</a> — the interactive views.</li>
+      <li>Hosting: <a href="https://pages.github.com/">GitHub Pages</a>.</li>
+    </ul>
+
+    <h2>Type &amp; assets</h2>
+    <ul>
+      <li><strong>Goudy Initialen</strong> dropcaps — public-domain initial-letter fonts (used on the personal side).</li>
+      <li><strong>Metroid Prime</strong> logo — public domain, via Wikimedia Commons (Nintendo wordmark; used editorially).</li>
+      <li><a href="https://arslankazmi.github.io/ak-design/">ak-design</a> — this site's own shared design system.</li>
+      <li>Lofi streams on the now-playing strip: <a href="https://www.youtube.com/@HenrikoMagnifico">Henriko Magnifico</a>,
+        <a href="https://www.youtube.com/@nestalgiamusic">Nestalgia</a>, and
+        <a href="https://www.youtube.com/@LofiGirl">Lofi Girl</a>.</li>
+    </ul>
+
+    <hr/>
+    <p class="note">Per-asset licensing detail lives in <code>ASSET_CREDITS.md</code> in the repository. If you see
+      something of yours here that should be credited differently — or not at all — please get in touch.</p>
+    <p class="back"><a href="/">← home</a> · <a href="/dev/">arslan.dev</a> · <a href="/personal/">arslan.land</a></p>
+  </main>
+</body>
+</html>

--- a/data/annotations.cache.json
+++ b/data/annotations.cache.json
@@ -1,0 +1,53 @@
+{
+  "https://en.wikipedia.org/wiki/Hypertext": {
+    "type": "wikipedia",
+    "title": "Hypertext",
+    "excerpt": "Hypertext is text displayed on a computer display or other electronic devices with references (hyperlinks) to other text that the reader can immediately access. Hypertext documents are interconnected by hyperlinks, which are typically activated by a mouse click, keypress set, or screen touch. Apart from text, the term \"hypertext\" is also used to describe tables, images, and other presentational materials with integrated hyperlinks. Hypertext is one of the key underlying concepts of the World Wide Web, where Web pages are often written in the Hypertext Markup Language (HTML). As implemented on the Web, hypertext enables the easy-to-use publication of information over the Internet.",
+    "thumb": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Hyperlinks_scheme.svg/330px-Hyperlinks_scheme.svg.png",
+    "url": "https://en.wikipedia.org/wiki/Hypertext"
+  },
+  "https://arxiv.org/abs/1706.03762": {
+    "type": "arxiv",
+    "title": "Attention Is All You Need",
+    "author": "Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin",
+    "excerpt": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks in an encoder-decoder configuration. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature. We show that the Transformer generalizes well to other tasks by applying it successfully to English constituency parsing both with large and limited training data.",
+    "url": "https://arxiv.org/abs/1706.03762"
+  },
+  "/personal/p/a-quiet-demo/": {
+    "type": "post",
+    "title": "A quiet demo",
+    "excerpt": "The same reading machinery, on the paper side — sidenotes that know when to stay out of the way.",
+    "date": "Jun 10, 2026",
+    "tags": [
+      "notebook"
+    ],
+    "read": "3 min",
+    "url": "/personal/p/a-quiet-demo/"
+  },
+  "https://en.wikipedia.org/wiki/Webring": {
+    "type": "wikipedia",
+    "title": "Webring",
+    "excerpt": "A webring is a collection of websites linked together in a circular structure, usually organized around a specific theme, and often educational or social. They were popular in the 1990s and early 2000s, particularly among amateur websites.",
+    "thumb": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/97/Webringwork.png/330px-Webringwork.png",
+    "url": "https://en.wikipedia.org/wiki/Webring"
+  },
+  "/dev/p/sidenotes-and-previews/": {
+    "type": "post",
+    "title": "Sidenotes, previews, and other quiet machinery",
+    "excerpt": "A demo post wiring up margin sidenotes and hover previews — and a note on why both degrade to plain text.",
+    "date": "Jun 10, 2026",
+    "tags": [
+      "meta",
+      "web",
+      "typography"
+    ],
+    "read": "4 min",
+    "url": "/dev/p/sidenotes-and-previews/"
+  },
+  "/assets/metroid-prime.png": {
+    "type": "image",
+    "title": "The Metroid Prime logo",
+    "src": "/assets/metroid-prime.png",
+    "url": "/assets/metroid-prime.png"
+  }
+}

--- a/data/snapshot.cache.json
+++ b/data/snapshot.cache.json
@@ -1,0 +1,96 @@
+{
+  "repos": [
+    {
+      "name": "Receipt OCR",
+      "desc": "A full ML/AI suite for receipt OCR: data prep with WebDataset sharding (200 images → 550 GB), a multi-model evaluation harness (Donut, Qwen2-VL, TrOCR, Claude), a Donut finetune, and a FastAPI inference service.",
+      "lang": "Python",
+      "url": "https://github.com/arslankazmi/receipt-ocr",
+      "docs": "https://arslankazmi.github.io/receipt-ocr/"
+    },
+    {
+      "name": "Jedi Council",
+      "desc": "A multi-agent Jedi Council deliberation system built on LangGraph — persona agents debate in public and private rounds, orchestrated through a shared graph, with a retro RPG overlay on top.",
+      "lang": "Python",
+      "url": "https://github.com/arslankazmi/jedi-council",
+      "docs": "https://arslankazmi.github.io/jedi-council/"
+    },
+    {
+      "name": "Research Radar",
+      "desc": "A custom OpenClaw plugin: a conversational, multi-source ML research radar with LLM-judged relevance that learns from your in-chat 👍/👎 feedback over time.",
+      "lang": "TypeScript",
+      "url": "https://github.com/arslankazmi/research-radar",
+      "docs": "https://arslankazmi.github.io/research-radar/"
+    },
+    {
+      "name": "Document AI Pipeline",
+      "desc": "End-to-end Document AI pipeline for handwritten form extraction, with a human-in-the-loop feedback loop that turns corrections into better models.",
+      "lang": "Python",
+      "url": "https://github.com/arslankazmi/doc-ai-pipeline",
+      "docs": "https://arslankazmi.github.io/doc-ai-pipeline/"
+    },
+    {
+      "name": "LangGraph Research Agent",
+      "desc": "Multi-agent equity-research system with verification gates and citation tracking, built on LangGraph + Postgres + LangSmith and served via FastAPI.",
+      "lang": "Python",
+      "url": "https://github.com/arslankazmi/langgraph-research-agent",
+      "docs": ""
+    },
+    {
+      "name": "StarCraft II Player Skill Classification",
+      "desc": "Classifies StarCraft II players by skill tier from gameplay telemetry — feature engineering and supervised modelling on behavioural data.",
+      "lang": "Python",
+      "url": "https://github.com/arslankazmi/StarCraft-II-Player-Skill-Classification",
+      "docs": ""
+    },
+    {
+      "name": "FastAPI ML Template",
+      "desc": "Production-ready FastAPI + ML template: versioned routers, per-version Swagger docs, uv dependency management, and Docker out of the box.",
+      "lang": "Python",
+      "url": "https://github.com/arslankazmi/fastapi-ml-template",
+      "docs": ""
+    },
+    {
+      "name": "Git Scrub — Visual History Explorer",
+      "desc": "An interactive visual git-history explorer with sliders to scrub through commits — built entirely with Claude Code.",
+      "lang": "JavaScript",
+      "url": "https://github.com/arslankazmi/ai-coded-git-scrub",
+      "docs": "https://arslankazmi.github.io/ai-coded-git-scrub/"
+    },
+    {
+      "name": "ak-ai — Claude Code Skills & Tools",
+      "desc": "Open-source Claude Code skills, agents, and AI tooling — reusable building blocks for agent-driven engineering.",
+      "lang": "",
+      "url": "https://github.com/arslankazmi/ak-ai",
+      "docs": ""
+    },
+    {
+      "name": "AI Poetry",
+      "desc": "Poems written by AI models, presented in the namesake forms of the models that wrote them.",
+      "lang": "HTML",
+      "url": "https://github.com/arslankazmi/ai-poetry",
+      "docs": "https://arslankazmi.github.io/ai-poetry/"
+    }
+  ],
+  "stats": [
+    {
+      "ico": "◆ repos",
+      "num": "29",
+      "cap": "public"
+    },
+    {
+      "ico": "✦ stars",
+      "num": "1",
+      "cap": "across repos"
+    },
+    {
+      "ico": "❂ followers",
+      "num": "4",
+      "cap": "on github"
+    },
+    {
+      "ico": "⌁ since",
+      "num": "9y",
+      "cap": "est. 2017"
+    }
+  ]
+}

--- a/dev/Shared.jsx
+++ b/dev/Shared.jsx
@@ -97,7 +97,7 @@ function DHFooter() {
   return (
     <footer className="dh-foot">
       <div>
-        Written by hand · built on the Arslan Kazmi design system · <a href="../personal/">the personal side ↗</a><br/>
+        Written by hand · built on the Arslan Kazmi design system · <a href="/acknowledgements/">acknowledgements</a> · <a href="../personal/">the personal side ↗</a><br/>
         <span className="ai-note">AI may have been used to fix the code.</span>
       </div>
       <span className="sig">— A.K.</span>

--- a/dev/index.html
+++ b/dev/index.html
@@ -11,12 +11,16 @@
   <link rel="stylesheet" href="styles.css"/>
   <link rel="stylesheet" href="../shared/reading-playing.css"/>
   <link rel="stylesheet" href="../shared/plain.css"/>
+  <link rel="stylesheet" href="../shared/sidenotes.css"/>
+  <link rel="stylesheet" href="../shared/previews.css"/>
   <script>try{if(localStorage.getItem("ak-view")==="plain")document.documentElement.setAttribute("data-view","plain");}catch(e){}</script>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked-footnote@1.4.0/dist/index.umd.js"></script>
+  <script>try{if(window.marked&&window.markedFootnote)marked.use(markedFootnote());}catch(e){}</script>
   <!-- Pure block/render functions (built from blocks.mjs + ../shared/render.mjs by esbuild). -->
   <script src="globals.js"></script>
 </head>
@@ -33,5 +37,7 @@
   <script type="text/babel" src="../shared/reading-playing.jsx"></script>
   <script type="text/babel" src="../shared/plain.jsx"></script>
   <script type="text/babel" src="app.jsx"></script>
+  <script src="../shared/sidenotes.js" defer></script>
+  <script src="../shared/previews.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
     <div class="seam"></div>
   </div>
   <div class="disclaimer">
-    <a href="./portfolio/">project catalog ↗</a> · written by hand · AI may have been used to fix the code.
+    <a href="./portfolio/">project catalog ↗</a> · <a href="./acknowledgements/">acknowledgements</a> · written by hand · AI may have been used to fix the code.
   </div>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "arslankazmi-github-io",
       "version": "1.0.0",
+      "dependencies": {
+        "marked-footnote": "^1.4.0"
+      },
       "devDependencies": {
         "esbuild": "^0.28.0",
         "marked": "^18.0.5"
@@ -500,13 +503,21 @@
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
       "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/marked-footnote": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/marked-footnote/-/marked-footnote-1.4.0.tgz",
+      "integrity": "sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=7.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "esbuild": "^0.28.0",
     "marked": "^18.0.5"
+  },
+  "dependencies": {
+    "marked-footnote": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "index": "node scripts/build-index.mjs",
     "build": "node scripts/build.mjs",
     "build:drafts": "DRAFTS=1 node scripts/build.mjs",
+    "build:refresh": "REFRESH=1 node scripts/build.mjs",
+    "bench": "node scripts/bench.mjs",
     "serve": "python3 -m http.server --directory _public 8080"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "index": "node scripts/build-index.mjs",
     "build": "node scripts/build.mjs",
+    "build:drafts": "DRAFTS=1 node scripts/build.mjs",
     "serve": "python3 -m http.server --directory _public 8080"
   },
   "devDependencies": {

--- a/personal/Footer.jsx
+++ b/personal/Footer.jsx
@@ -3,7 +3,7 @@ function Footer() {
   return (
     <footer className="footer">
       <div>
-        Written by hand.<br/>
+        Written by hand · <a href="/acknowledgements/">acknowledgements</a>.<br/>
         © {new Date().getFullYear()} Arslan Kazmi · No cookies, no analytics, no rush.<br/>
         <span className="ai-note">AI may have been used to fix the code.</span>
       </div>

--- a/personal/index.html
+++ b/personal/index.html
@@ -11,12 +11,16 @@
   <link rel="stylesheet" href="styles.css"/>
   <link rel="stylesheet" href="../shared/reading-playing.css"/>
   <link rel="stylesheet" href="../shared/plain.css"/>
+  <link rel="stylesheet" href="../shared/sidenotes.css"/>
+  <link rel="stylesheet" href="../shared/previews.css"/>
   <script>try{if(localStorage.getItem("ak-view")==="plain")document.documentElement.setAttribute("data-view","plain");}catch(e){}</script>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked-footnote@1.4.0/dist/index.umd.js"></script>
+  <script>try{if(window.marked&&window.markedFootnote)marked.use(markedFootnote());}catch(e){}</script>
   <!-- Pure block/render functions (built from blocks.mjs + ../shared/render.mjs by esbuild). -->
   <script src="globals.js"></script>
 </head>
@@ -36,5 +40,7 @@
   <script type="text/babel" src="../shared/reading-playing.jsx"></script>
   <script type="text/babel" src="../shared/plain.jsx"></script>
   <script type="text/babel" src="app.jsx"></script>
+  <script src="../shared/sidenotes.js" defer></script>
+  <script src="../shared/previews.js" defer></script>
 </body>
 </html>

--- a/posts.json
+++ b/posts.json
@@ -15,6 +15,7 @@
       "blurb": "A demo post wiring up margin sidenotes and hover previews — and a note on why both degrade to plain text.",
       "read": "4 min",
       "featured": true,
+      "draft": false,
       "path": "posts/dev/2026-06-10-sidenotes-and-previews.md"
     }
   ],
@@ -32,6 +33,7 @@
       "blurb": "The same reading machinery, on the paper side — sidenotes that know when to stay out of the way.",
       "read": "3 min",
       "featured": false,
+      "draft": false,
       "path": "posts/personal/2026-06-10-a-quiet-demo.md"
     }
   ]

--- a/posts.json
+++ b/posts.json
@@ -1,4 +1,38 @@
 {
-  "dev": [],
-  "personal": []
+  "dev": [
+    {
+      "slug": "sidenotes-and-previews",
+      "side": "dev",
+      "title": "Sidenotes, previews, and other quiet machinery",
+      "date": "Jun 2026",
+      "dateLong": "Jun 10, 2026",
+      "iso": "2026-06-10",
+      "tags": [
+        "meta",
+        "web",
+        "typography"
+      ],
+      "blurb": "A demo post wiring up margin sidenotes and hover previews — and a note on why both degrade to plain text.",
+      "read": "4 min",
+      "featured": true,
+      "path": "posts/dev/2026-06-10-sidenotes-and-previews.md"
+    }
+  ],
+  "personal": [
+    {
+      "slug": "a-quiet-demo",
+      "side": "personal",
+      "title": "A quiet demo",
+      "date": "Jun 2026",
+      "dateLong": "Jun 10, 2026",
+      "iso": "2026-06-10",
+      "tags": [
+        "notebook"
+      ],
+      "blurb": "The same reading machinery, on the paper side — sidenotes that know when to stay out of the way.",
+      "read": "3 min",
+      "featured": false,
+      "path": "posts/personal/2026-06-10-a-quiet-demo.md"
+    }
+  ]
 }

--- a/posts/dev/2026-06-10-sidenotes-and-previews.md
+++ b/posts/dev/2026-06-10-sidenotes-and-previews.md
@@ -1,0 +1,24 @@
+---
+title: Sidenotes, previews, and other quiet machinery
+date: 2026-06-10
+tags: [meta, web, typography]
+blurb: A demo post wiring up margin sidenotes and hover previews — and a note on why both degrade to plain text.
+read: 4 min
+featured: true
+---
+
+This post exists to exercise the reading machinery: margin **sidenotes**, hover **previews**, and embedded images. None of it is required to read the words — that's the whole point.[^why]
+
+Sidenotes are the good kind of footnote. On a wide screen the note floats into the margin next to its reference, so you can read it without losing your place.[^tufte] On a narrow screen, or with JavaScript off, the same note simply appears at the bottom as an ordinary footnote.[^degrade]
+
+Hover previews are compiled at build time, not fetched live. A link to [the Wikipedia article on hypertext](https://en.wikipedia.org/wiki/Hypertext) carries a small card; so does a paper like [Attention Is All You Need](https://arxiv.org/abs/1706.03762). Internal links — say, [the quiet demo on the other side](/personal/p/a-quiet-demo/) — pull their card straight from the post index.
+
+Images work too, and zoom on hover:
+
+![The Metroid Prime logo](/assets/metroid-prime.png)
+
+That's the whole demo. Delete this file whenever real posts arrive.
+
+[^why]: Progressive enhancement: the page is readable first, and the niceties layer on top only where the browser and viewport allow.
+[^tufte]: The pattern is Edward Tufte's, popularized in Tufte-CSS and adapted by gwern.net.
+[^degrade]: This footnote is proof — resize the window narrow (or disable JS) and watch it slide back to the bottom of the article.

--- a/posts/personal/2026-06-10-a-quiet-demo.md
+++ b/posts/personal/2026-06-10-a-quiet-demo.md
@@ -1,0 +1,17 @@
+---
+title: A quiet demo
+date: 2026-06-10
+tags: [notebook]
+blurb: The same reading machinery, on the paper side — sidenotes that know when to stay out of the way.
+read: 3 min
+featured: false
+---
+
+I wanted the margin notes to feel like marginalia in a used book — there when you glance over, gone when the page is small.[^margin]
+
+The trick is restraint. A note only floats to the margin when there's genuine room for it; otherwise it waits politely at the foot of the page.[^room] You can link out, too — to [Wikipedia on the webring](https://en.wikipedia.org/wiki/Webring), say — and a little card appears without taking you anywhere.
+
+There's a louder version of all this on [the dev side](/dev/p/sidenotes-and-previews/), with the same parts described more mechanically.
+
+[^margin]: Marginalia is older than the printed book; medieval scribes filled the gutters with glosses, pointing hands, and the occasional drawing of a snail.
+[^room]: "Room" is measured at runtime from the actual column position — so it adapts to the window rather than assuming a fixed width.

--- a/scripts/annotations.mjs
+++ b/scripts/annotations.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+/**
+ * scripts/annotations.mjs
+ * Build-time link/image preview annotations for the static site.
+ *
+ * Usage (from build.mjs or standalone):
+ *   import { buildAnnotations } from "./scripts/annotations.mjs";
+ *   const stats = await buildAnnotations({ repo, posts, outFile, cacheFile });
+ *
+ * @param {object} opts
+ * @param {string} opts.repo     - absolute path to repo root
+ * @param {object} opts.posts    - { dev: [...], personal: [...] } post index
+ * @param {string} opts.outFile  - where to write merged annotations.json (e.g. _public/annotations.json)
+ * @param {string} opts.cacheFile - committed cache path (e.g. <repo>/data/annotations.cache.json)
+ * @returns {Promise<{count:number, resolved:number, fromCache:number, unresolved:number}>}
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const FETCH_TIMEOUT_MS = 6000;
+
+/**
+ * fetch with AbortController timeout. Returns null on any error.
+ */
+async function fetchSafe(url, timeoutMs = FETCH_TIMEOUT_MS) {
+  const ctrl = new AbortController();
+  const tid = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { "User-Agent": "annotations-bot/1.0" } });
+    clearTimeout(tid);
+    return res;
+  } catch (e) {
+    clearTimeout(tid);
+    throw e;
+  }
+}
+
+/**
+ * Pull a single meta-tag value from raw HTML via regex.
+ * Handles both property= and name= variants, single/double quotes.
+ */
+function metaContent(html, propName) {
+  const re = new RegExp(
+    `<meta[^>]+(?:property|name)=["']${propName}["'][^>]+content=["']([^"']*?)["']` +
+    `|<meta[^>]+content=["']([^"']*?)["'][^>]+(?:property|name)=["']${propName}["']`,
+    "i"
+  );
+  const m = html.match(re);
+  return m ? (m[1] || m[2] || "").trim() : "";
+}
+
+/**
+ * Extract <title>…</title> from HTML.
+ */
+function htmlTitle(html) {
+  const m = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  return m ? m[1].trim() : "";
+}
+
+/**
+ * Decode a percent-encoded URL path segment into a readable filename.
+ */
+function decodedFilename(url) {
+  try {
+    const u = new URL(url);
+    const parts = u.pathname.split("/").filter(Boolean);
+    return decodeURIComponent(parts[parts.length - 1] || u.hostname);
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Return the hostname of a URL, or "" on failure.
+ */
+function hostname(url) {
+  try { return new URL(url).hostname; } catch { return ""; }
+}
+
+// ─── Per-type resolvers ──────────────────────────────────────────────────────
+
+const FILE_EXTS = new Set([".pdf", ".doc", ".docx", ".epub", ".zip", ".tar", ".gz", ".xls", ".xlsx", ".ppt", ".pptx"]);
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".avif"]);
+
+/**
+ * Given all posts flattened, build a slug → post lookup.
+ */
+function buildPostLookup(posts) {
+  const map = new Map();
+  for (const side of ["dev", "personal"]) {
+    for (const p of (posts[side] || [])) {
+      map.set(p.slug, p);
+    }
+  }
+  return map;
+}
+
+/**
+ * Detect if url is an internal post link and return the slug, else null.
+ * Matches: #/p/<slug>  |  /dev/p/<slug>/  |  /personal/p/<slug>/
+ */
+function internalPostSlug(url) {
+  let m;
+  m = url.match(/^#\/p\/([^/?#]+)/);
+  if (m) return m[1];
+  m = url.match(/\/(?:dev|personal)\/p\/([^/?#/]+)\/?$/);
+  if (m) return m[1];
+  return null;
+}
+
+/**
+ * Detect Wikipedia URL and return { lang, title } or null.
+ */
+function parseWikipedia(url) {
+  const m = url.match(/^https?:\/\/([a-z-]+)\.wikipedia\.org\/wiki\/(.+)$/i);
+  if (!m) return null;
+  return { lang: m[1], title: m[2].split("#")[0] };
+}
+
+/**
+ * Detect arXiv URL and return paper ID or null.
+ * Handles abs/<id> and pdf/<id>(.pdf)
+ */
+function parseArxiv(url) {
+  const m = url.match(/arxiv\.org\/(?:abs|pdf)\/([0-9]+\.[0-9]+(?:v[0-9]+)?)/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Get file extension (lowercase, with dot) or "" if none.
+ */
+function getExt(url) {
+  try {
+    const pathname = new URL(url).pathname;
+    const last = pathname.split("/").pop() || "";
+    const dot = last.lastIndexOf(".");
+    return dot >= 0 ? last.slice(dot).toLowerCase() : "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Resolve a record for a single URL. Never throws.
+ */
+async function resolveUrl(url, postLookup, altText) {
+  try {
+    // ── Internal post link ────────────────────────────────────────────────
+    const slug = internalPostSlug(url);
+    if (slug) {
+      const p = postLookup.get(slug);
+      if (p) {
+        return {
+          type: "post",
+          title: p.title,
+          excerpt: p.blurb || "",
+          date: p.dateLong || p.date || "",
+          tags: p.tags || [],
+          read: p.read || "",
+          url,
+        };
+      }
+      // slug not found in posts.json — fall through to generic
+    }
+
+    // ── IMAGE (from alt-text context OR image extension) ──────────────────
+    if (altText !== undefined) {
+      // Called from an image scan — always treat as image type
+      return {
+        type: "image",
+        title: altText || decodedFilename(url),
+        src: url,
+        url,
+      };
+    }
+
+    const ext = getExt(url);
+
+    if (IMAGE_EXTS.has(ext)) {
+      return { type: "image", title: decodedFilename(url), src: url, url };
+    }
+
+    // ── File download ────────────────────────────────────────────────────
+    if (FILE_EXTS.has(ext)) {
+      return { type: "file", title: decodedFilename(url), ext: ext.replace(".", ""), url };
+    }
+
+    // ── Wikipedia ────────────────────────────────────────────────────────
+    const wiki = parseWikipedia(url);
+    if (wiki) {
+      const apiUrl = `https://${wiki.lang}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(wiki.title)}`;
+      const res = await fetchSafe(apiUrl);
+      if (res && res.ok) {
+        const data = await res.json();
+        return {
+          type: "wikipedia",
+          title: data.title || wiki.title,
+          excerpt: data.extract || "",
+          thumb: data.thumbnail?.source || null,
+          url,
+        };
+      }
+      // 404 or error — minimal record
+      return { type: "wikipedia", title: decodeURIComponent(wiki.title.replace(/_/g, " ")), url };
+    }
+
+    // ── arXiv ────────────────────────────────────────────────────────────
+    const arxivId = parseArxiv(url);
+    if (arxivId) {
+      const apiUrl = `https://export.arxiv.org/api/query?id_list=${arxivId}`;
+      const res = await fetchSafe(apiUrl);
+      if (res && res.ok) {
+        const xml = await res.text();
+        // Scope to the <entry> block — the feed-level <title> is just the query echo.
+        const entry = (xml.match(/<entry>([\s\S]*?)<\/entry>/) || [])[1] || xml;
+        const title = (entry.match(/<title>([\s\S]*?)<\/title>/) || [])[1]?.replace(/\s+/g, " ").trim() || arxivId;
+        const summary = (entry.match(/<summary>([\s\S]*?)<\/summary>/) || [])[1]?.replace(/\s+/g, " ").trim() || "";
+        const authorMatches = [...entry.matchAll(/<name>([^<]+)<\/name>/g)];
+        const authors = authorMatches.map(m => m[1].trim());
+        return {
+          type: "arxiv",
+          title,
+          author: authors.join(", "),
+          excerpt: summary,
+          url,
+        };
+      }
+      return { type: "arxiv", title: arxivId, url };
+    }
+
+    // ── Generic HTTP(S) — OpenGraph scrape ───────────────────────────────
+    if (/^https?:\/\//.test(url)) {
+      try {
+        const res = await fetchSafe(url);
+        if (res && res.ok) {
+          // Only read up to 64 KB to avoid memory issues with large pages
+          const reader = res.body?.getReader();
+          let raw = "";
+          if (reader) {
+            const decoder = new TextDecoder();
+            let total = 0;
+            while (total < 65536) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              raw += decoder.decode(value, { stream: true });
+              total += value.byteLength;
+            }
+            reader.cancel();
+          } else {
+            raw = await res.text();
+          }
+
+          const ogTitle = metaContent(raw, "og:title");
+          const ogDesc  = metaContent(raw, "og:description");
+          const ogImage = metaContent(raw, "og:image");
+          const twitterTitle = metaContent(raw, "twitter:title");
+          const twitterDesc  = metaContent(raw, "twitter:description");
+          const twitterImage = metaContent(raw, "twitter:image");
+          const fallbackTitle = htmlTitle(raw);
+
+          const title   = ogTitle || twitterTitle || fallbackTitle || hostname(url);
+          const excerpt = ogDesc  || twitterDesc  || "";
+          const thumb   = ogImage || twitterImage || null;
+
+          return { type: "link", title, excerpt, thumb, source: hostname(url), url };
+        }
+      } catch (fetchErr) {
+        // fall through to minimal record below
+      }
+      return { type: "link", title: hostname(url), source: hostname(url), url };
+    }
+
+    // ── Unrecognised scheme (mailto:, ftp:, etc.) ─────────────────────────
+    return { type: "link", title: url, url };
+
+  } catch (err) {
+    console.log("[annotations] unresolved:", url, err.message);
+    return { type: "link", title: hostname(url) || url, url };
+  }
+}
+
+// ─── Markdown scanning ───────────────────────────────────────────────────────
+
+/**
+ * Scan markdown text and return:
+ *   links: Array<{ url: string }>
+ *   images: Array<{ url: string, alt: string }>
+ *
+ * Skips code spans/blocks to avoid false positives.
+ */
+function scanMarkdown(md) {
+  // Strip fenced code blocks
+  const stripped = md.replace(/```[\s\S]*?```/g, "").replace(/`[^`]+`/g, "");
+
+  const links  = [];
+  const images = [];
+  const seenUrls = new Set();
+
+  // Images: ![alt](src)  — must come before link scan to avoid overlap
+  const imgRe = /!\[([^\]]*)\]\(([^)]+)\)/g;
+  let m;
+  while ((m = imgRe.exec(stripped)) !== null) {
+    const url = m[2].trim().split(/\s+/)[0]; // drop optional title
+    const alt = m[1].trim();
+    if (url && !seenUrls.has("img:" + url)) {
+      seenUrls.add("img:" + url);
+      images.push({ url, alt });
+    }
+  }
+
+  // Links: [text](url)  — skip if preceded by ! (already captured as image)
+  const linkRe = /(?<!!)\[([^\]]*)\]\(([^)]+)\)/g;
+  while ((m = linkRe.exec(stripped)) !== null) {
+    const url = m[2].trim().split(/\s+/)[0];
+    if (url && !seenUrls.has("link:" + url)) {
+      seenUrls.add("link:" + url);
+      links.push({ url });
+    }
+  }
+
+  return { links, images };
+}
+
+// ─── Main export ─────────────────────────────────────────────────────────────
+
+/**
+ * Build link/image preview annotations for the static site.
+ *
+ * @param {object} opts
+ * @param {string} opts.repo        Absolute path to repo root.
+ * @param {object} opts.posts       { dev: [...], personal: [...] } post index.
+ * @param {string} opts.outFile     Destination path for the merged annotations JSON (written to _public/).
+ * @param {string} opts.cacheFile   Committed cache path (e.g. <repo>/data/annotations.cache.json).
+ * @returns {Promise<{count:number, resolved:number, fromCache:number, unresolved:number}>}
+ */
+export async function buildAnnotations({ repo, posts, outFile, cacheFile }) {
+  // ── Load existing cache ────────────────────────────────────────────────
+  let cache = {};
+  if (cacheFile && existsSync(cacheFile)) {
+    try { cache = JSON.parse(readFileSync(cacheFile, "utf8")); } catch {}
+  }
+
+  // ── Load hand-written overrides (WIN over everything) ─────────────────
+  let overrides = {};
+  const overridesFile = join(repo, "data", "annotations.json");
+  if (existsSync(overridesFile)) {
+    try { overrides = JSON.parse(readFileSync(overridesFile, "utf8")); } catch {}
+  }
+
+  // ── Scan all post markdown files for unique targets ───────────────────
+  const postLookup = buildPostLookup(posts);
+  const allLinks  = new Map(); // url -> null (links)
+  const allImages = new Map(); // url -> alt   (images — first alt seen)
+
+  for (const side of ["dev", "personal"]) {
+    for (const post of (posts[side] || [])) {
+      const mdPath = join(repo, post.path);
+      if (!existsSync(mdPath)) continue;
+      let md;
+      try { md = readFileSync(mdPath, "utf8"); } catch { continue; }
+      const { links, images } = scanMarkdown(md);
+      for (const { url } of links) {
+        if (!allLinks.has(url)) allLinks.set(url, null);
+      }
+      for (const { url, alt } of images) {
+        if (!allImages.has(url)) allImages.set(url, alt);
+      }
+    }
+  }
+
+  // ── Resolve records for anything not already cached/overridden ─────────
+  let resolvedCount = 0;
+  let fromCacheCount = 0;
+  let unresolvedCount = 0;
+
+  const merged = { ...cache }; // start from cache
+
+  // Process links
+  const linkUrls = [...allLinks.keys()];
+  for (const url of linkUrls) {
+    if (overrides[url]) continue; // will be applied at merge step
+    if (merged[url]) { fromCacheCount++; continue; }
+    try {
+      merged[url] = await resolveUrl(url, postLookup, undefined);
+      resolvedCount++;
+    } catch (err) {
+      console.log("[annotations] unresolved:", url, err.message);
+      merged[url] = { type: "link", title: hostname(url) || url, url };
+      unresolvedCount++;
+    }
+  }
+
+  // Process images
+  const imageUrls = [...allImages.keys()];
+  for (const url of imageUrls) {
+    if (overrides[url]) continue;
+    if (merged[url]) { fromCacheCount++; continue; }
+    try {
+      const alt = allImages.get(url) || "";
+      merged[url] = await resolveUrl(url, postLookup, alt);
+      resolvedCount++;
+    } catch (err) {
+      console.log("[annotations] unresolved (img):", url, err.message);
+      merged[url] = { type: "image", title: allImages.get(url) || decodedFilename(url), src: url, url };
+      unresolvedCount++;
+    }
+  }
+
+  // Apply overrides (highest precedence)
+  for (const [url, record] of Object.entries(overrides)) {
+    merged[url] = record;
+  }
+
+  // ── Persist cache (committed) ──────────────────────────────────────────
+  if (cacheFile) {
+    const cacheDir = dirname(cacheFile);
+    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(cacheFile, JSON.stringify(merged, null, 2), "utf8");
+  }
+
+  // ── Write output for the browser ──────────────────────────────────────
+  if (outFile) {
+    const outDir = dirname(outFile);
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+    writeFileSync(outFile, JSON.stringify(merged), "utf8");
+  }
+
+  const count = Object.keys(merged).length;
+  console.log(
+    `[annotations] done — total:${count} resolved:${resolvedCount} fromCache:${fromCacheCount} unresolved:${unresolvedCount} overrides:${Object.keys(overrides).length}`
+  );
+
+  return { count, resolved: resolvedCount, fromCache: fromCacheCount, unresolved: unresolvedCount };
+}

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/* bench.mjs — build-performance microbenchmarks, to track speed over time and sanity-check against
+   the Hugo/Jekyll mental model. Measures the compute that scales with content (index scan, markdown→
+   HTML render throughput, esbuild bundling) separately from the one-off network snapshot. Run: `npm run bench`. */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { marked } from "marked";
+import markedFootnote from "marked-footnote";
+import * as esbuild from "esbuild";
+import { buildIndex } from "./build-index.mjs";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+marked.use(markedFootnote());
+
+function ms(t) { return Number(process.hrtime.bigint() - t) / 1e6; }
+const fmt = (n) => `${n.toFixed(n < 10 ? 2 : 0)} ms`;
+
+// 1. Index scan + front-matter parse (pure, no network).
+let t = process.hrtime.bigint();
+const idx = buildIndex(REPO);
+const idxMs = ms(t);
+const realPosts = (idx.dev.length + idx.personal.length) || 1;
+
+// 2. Markdown → HTML render throughput on a representative body.
+const body = `# Heading\n\nSome **markdown** with a [link](https://example.com), \`code\`, and a footnote[^1].\n\n`.repeat(8)
+  + "## Section\n\nMore prose, lists, and the occasional aside. ".repeat(30) + "\n\n[^1]: A footnote body.\n";
+const N = 1000;
+t = process.hrtime.bigint();
+let outChars = 0;
+for (let i = 0; i < N; i++) outChars += marked.parse(body).length;
+const renderMs = ms(t);
+
+// 3. esbuild bundling (the two browser globals IIFEs).
+t = process.hrtime.bigint();
+for (const side of ["dev", "personal"]) {
+  await esbuild.build({ entryPoints: [join(REPO, side, "_globals.mjs")], bundle: true, format: "iife", minify: true, write: false });
+}
+const esbuildMs = ms(t);
+
+const perPost = renderMs / N;
+console.log(`\n  build benchmark (compute only — excludes the cached/network snapshot)\n`);
+console.log(`  index scan (${realPosts} real posts)   ${fmt(idxMs)}`);
+console.log(`  render throughput              ${fmt(renderMs)} for ${N} posts  →  ${perPost.toFixed(2)} ms/post`);
+console.log(`  esbuild (2 bundles)            ${fmt(esbuildMs)}`);
+console.log(`\n  projected render at scale:  100 posts ≈ ${fmt(perPost * 100)} · 1000 posts ≈ ${fmt(perPost * 1000)}`);
+console.log(`  (ref: Hugo ≈ 1 ms/page, Jekyll ≈ 10–50 ms/page; our network snapshot is cached by default)\n`);

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -34,6 +34,10 @@ function parseFront(raw) {
 const short = (iso) => { const [y, mo] = iso.split("-"); return `${MONTHS[+mo - 1]} ${y}`; };
 const long = (iso) => { const [y, mo, d] = iso.split("-"); return `${MONTHS[+mo - 1]} ${+d}, ${y}`; };
 
+// Posts with `draft: true` front-matter are excluded from the build (no index entry, page, or
+// listing) — unless DRAFTS=1 is set, which includes them for local preview (cf. Hugo --buildDrafts).
+const INCLUDE_DRAFTS = !!process.env.DRAFTS;
+
 function collect(repo, side) {
   const dir = join(repo, "posts", side);
   if (!existsSync(dir)) return [];
@@ -53,9 +57,11 @@ function collect(repo, side) {
         blurb: fm.blurb || "",
         read: fm.read || "",
         featured: fm.featured === "true",
+        draft: fm.draft === "true",
         path: `posts/${side}/${f}`,
       };
     })
+    .filter((p) => INCLUDE_DRAFTS || !p.draft)
     .sort((a, b) => (a.iso < b.iso ? 1 : -1));
 }
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -37,6 +37,15 @@ const PROJECTS_URL = "https://arslankazmi.github.io/portfolio/data/projects.json
 
 const log = (...a) => console.log("[build]", ...a);
 
+// Build-time data snapshot caching. Default builds reuse data/snapshot.cache.json (no network — fast,
+// like Hugo); the rich view still fetches GitHub live client-side, so the cached snapshot only feeds the
+// no-JS baseline. Refresh with `npm run build:refresh` (REFRESH=1); `--no-fetch`/NO_FETCH never hits the network.
+const SNAPSHOT_CACHE = join(REPO, "data", "snapshot.cache.json");
+const OFFLINE = !!process.env.NO_FETCH || process.argv.includes("--no-fetch");
+const REFRESH = !!process.env.REFRESH || process.argv.includes("--refresh");
+function readCache(file) { try { return existsSync(file) ? JSON.parse(readFileSync(file, "utf8")) : null; } catch { return null; } }
+function writeCache(file, obj) { try { mkdirSync(dirname(file), { recursive: true }); writeFileSync(file, JSON.stringify(obj, null, 2) + "\n"); } catch (e) { log("cache write failed:", e.message); } }
+
 /** Evaluate a browser data file (which assigns window.X = …) and return the populated window. */
 function loadWindowGlobals(file) {
   try {
@@ -59,8 +68,19 @@ function pruneFiles(dir, pred) {
   }
 }
 
-/** Build-time data snapshot for the dev hub (repos + GitHub stats), with graceful fallbacks. */
+/** Cache-aware dev snapshot: reuse data/snapshot.cache.json unless --refresh; --no-fetch stays offline. */
 async function devSnapshot(dh) {
+  const cached = readCache(SNAPSHOT_CACHE);
+  if (OFFLINE) { log(`snapshot: offline → ${cached ? "cache" : "sample stats"}`); return cached || { repos: [], stats: dh.stats || [] }; }
+  if (cached && !REFRESH) { log(`snapshot: from cache (${cached.repos.length} repos) — \`npm run build:refresh\` to update`); return cached; }
+  const fresh = await fetchSnapshot(dh);
+  writeCache(SNAPSHOT_CACHE, fresh);
+  log(`snapshot: fetched live (${fresh.repos.length} repos, ${fresh.stats.length} tiles) → cached`);
+  return fresh;
+}
+
+/** Fetch the live dev-hub data (portfolio repos + GitHub stats), with graceful fallbacks. */
+async function fetchSnapshot(dh) {
   let repos = [];
   try {
     const d = await (await fetch(PROJECTS_URL)).json();
@@ -184,7 +204,7 @@ async function main() {
   log(`snapshot: ${repos.length} repos, ${stats.length} stat tiles`);
 
   // 3. copy served tree
-  for (const item of ["assets", "shared", "dev", "personal", "posts"]) {
+  for (const item of ["assets", "shared", "dev", "personal", "posts", "acknowledgements"]) {
     if (existsSync(join(REPO, item))) cpSync(join(REPO, item), join(OUT, item), { recursive: true });
   }
   for (const f of ["index.html", ".nojekyll"]) {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,11 +18,16 @@ import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, existsSync, rea
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative } from "node:path";
 import { marked } from "marked";
+import markedFootnote from "marked-footnote";
 import * as esbuild from "esbuild";
 import { buildIndex } from "./build-index.mjs";
+import { buildAnnotations } from "./annotations.mjs";
 import { devBlocks } from "../dev/blocks.mjs";
 import { personalBlocks } from "../personal/blocks.mjs";
 import { toStaticHTML, he } from "../shared/render.mjs";
+
+// Footnotes (sidenotes.js enhances these into margin notes; degrade to bottom-footnotes no-JS).
+marked.use(markedFootnote());
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, "..");
@@ -136,6 +141,8 @@ function postPage(side, post, bodyHtml) {
   ${post.blurb ? `<meta name="description" content="${he(post.blurb)}"/>` : ""}
   <link rel="icon" type="image/svg+xml" href="../../../assets/favicon.svg"/>
   <link rel="stylesheet" href="${css}"/>
+  <link rel="stylesheet" href="/shared/sidenotes.css"/>
+  <link rel="stylesheet" href="/shared/previews.css"/>
   <style>
     .post { max-width: 42rem; margin: 0 auto; padding: 56px 20px 96px; }
     .post .meta { font-family: var(--font-mono, monospace); font-size: 13px; opacity: .7; margin-bottom: 10px; }
@@ -154,6 +161,8 @@ function postPage(side, post, bodyHtml) {
     <div class="prose">${bodyHtml}</div>
     <a class="back" href="../../">← all writing</a>
   </main>
+  <script src="/shared/sidenotes.js" defer></script>
+  <script src="/shared/previews.js" defer></script>
 </body>
 </html>
 `;
@@ -206,9 +215,11 @@ async function main() {
   emitShell("personal/index.html",
     personalBlocks({ route: "home", entries: personalEntries, rp: RP, projects: AK.PROJECTS || [] }), personalNav);
 
-  // 6. per-post static pages
+  // 6. per-post static pages (+ per-side image dir for absolute /<side>/img/... refs)
   let postCount = 0;
   for (const side of ["dev", "personal"]) {
+    const imgSrc = join(REPO, "posts", side, "img");
+    if (existsSync(imgSrc)) cpSync(imgSrc, join(OUT, side, "img"), { recursive: true });
     for (const post of index[side] || []) {
       const raw = readFileSync(join(REPO, post.path), "utf8").replace(/^---[\s\S]*?\r?\n---\r?\n?\s*/, "");
       const dir = join(OUT, side, "p", post.slug);
@@ -218,6 +229,15 @@ async function main() {
     }
   }
   log(`per-post pages: ${postCount}`);
+
+  // 7. build-time link/doc/image preview annotations (internal · wikipedia · arxiv · file · image · OG)
+  await buildAnnotations({
+    repo: REPO,
+    posts: index,
+    outFile: join(OUT, "annotations.json"),
+    cacheFile: join(REPO, "data", "annotations.cache.json"),
+  });
+
   log(`done -> ${relative(REPO, OUT)}/`);
 }
 

--- a/shared/previews.css
+++ b/shared/previews.css
@@ -1,0 +1,207 @@
+/* shared/previews.css — link/image preview card styles
+   Uses design-system tokens with safe fallbacks for both dark (dev) and light (personal) themes.
+   Link: <link rel="stylesheet" href="/shared/previews.css">
+*/
+
+/* ── Card container ─────────────────────────────────────────────────────── */
+.ak-preview-card {
+  position: absolute;
+  z-index: 9999;
+  display: none; /* shown via JS */
+
+  max-width: 360px;
+  min-width: 200px;
+  width: max-content;
+
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(128, 128, 128, 0.25));
+
+  background: var(--bg-elevated, #ffffff);
+  color: var(--fg1, #111111);
+
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.14),
+    0 1px 4px  rgba(0, 0, 0, 0.08);
+
+  font-family: var(--font-display, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  font-size: 0.85rem;
+  line-height: 1.45;
+
+  /* Clip long content */
+  word-break: break-word;
+  overflow-wrap: anywhere;
+
+  /* Subtle entrance (respects prefers-reduced-motion below) */
+  animation: ak-card-in 0.12s ease-out both;
+}
+
+@keyframes ak-card-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ak-preview-card {
+    animation: none;
+  }
+}
+
+/* ── Type badge ──────────────────────────────────────────────────────────── */
+.ak-preview-card__type {
+  display: inline-block;
+  font-family: var(--font-mono, "JetBrains Mono", "Fira Mono", "Courier New", monospace);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-bottom: 7px;
+
+  background: var(--accent-muted, rgba(100, 100, 255, 0.12));
+  color: var(--accent, #4a7fff);
+  border: 1px solid var(--accent-border, rgba(100, 100, 255, 0.25));
+}
+
+.ak-preview-card__type--wiki  { color: var(--fg2, #555); background: var(--bg-subtle, rgba(128,128,128,0.1)); border-color: var(--border, rgba(128,128,128,0.2)); }
+.ak-preview-card__type--arxiv { color: #c0392b; background: rgba(192,57,43,0.08); border-color: rgba(192,57,43,0.25); }
+.ak-preview-card__type--file  { color: var(--fg2, #555); background: var(--bg-subtle, rgba(128,128,128,0.1)); border-color: var(--border, rgba(128,128,128,0.2)); }
+
+/* ── Thumbnail ───────────────────────────────────────────────────────────── */
+.ak-preview-card__thumb {
+  display: block;
+  max-width: 100%;
+  max-height: 140px;
+  width: auto;
+  height: auto;
+  border-radius: 5px;
+  margin-bottom: 8px;
+  object-fit: cover;
+}
+
+/* ── Title ───────────────────────────────────────────────────────────────── */
+.ak-preview-card__title {
+  font-weight: 700;
+  font-size: 0.88rem;
+  color: var(--fg1, #111111);
+  margin-bottom: 4px;
+  line-height: 1.3;
+}
+
+/* ── Author (arXiv) ──────────────────────────────────────────────────────── */
+.ak-preview-card__author {
+  font-size: 0.76rem;
+  color: var(--fg2, #666666);
+  margin-bottom: 5px;
+  font-style: italic;
+}
+
+/* ── Excerpt ─────────────────────────────────────────────────────────────── */
+.ak-preview-card__excerpt {
+  font-size: 0.80rem;
+  color: var(--fg2, #555555);
+  margin-bottom: 5px;
+  line-height: 1.5;
+
+  /* Clamp at 4 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Post metadata ───────────────────────────────────────────────────────── */
+.ak-preview-card__meta {
+  font-size: 0.74rem;
+  color: var(--fg3, #888888);
+  margin-top: 4px;
+}
+
+.ak-preview-card__tags {
+  margin-top: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.ak-preview-card__tag {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.68rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-subtle, rgba(128,128,128,0.1));
+  color: var(--fg2, #555);
+  border: 1px solid var(--border, rgba(128,128,128,0.2));
+}
+
+/* ── Source line ─────────────────────────────────────────────────────────── */
+.ak-preview-card__source {
+  font-family: var(--font-mono, "JetBrains Mono", "Fira Mono", "Courier New", monospace);
+  font-size: 0.70rem;
+  color: var(--fg3, #999999);
+  margin-top: 6px;
+  padding-top: 5px;
+  border-top: 1px solid var(--border, rgba(128,128,128,0.15));
+}
+
+/* ── Image zoom variant ──────────────────────────────────────────────────── */
+.ak-preview-card.ak-preview-card--image-zoom {
+  padding: 6px;
+  max-width: min(480px, 90vw);
+  min-width: unset;
+  background: var(--bg-elevated, #ffffff);
+}
+
+.ak-preview-card--image > .ak-preview-card--image img,
+.ak-preview-card.ak-preview-card--image-zoom img {
+  display: block;
+  max-width: 100%;
+  max-height: 320px;
+  width: auto;
+  height: auto;
+  border-radius: 5px;
+  object-fit: contain;
+  margin: 0 auto;
+}
+
+.ak-preview-card__caption {
+  font-size: 0.74rem;
+  color: var(--fg2, #666666);
+  text-align: center;
+  margin-top: 5px;
+  font-style: italic;
+}
+
+/* ── "has-preview" link decoration ──────────────────────────────────────── */
+a.has-preview {
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  text-decoration-color: var(--accent, currentColor);
+}
+
+a.has-preview:hover,
+a.has-preview:focus {
+  text-decoration-style: solid;
+}
+
+/* ── Dark theme adjustments ──────────────────────────────────────────────── */
+/* When the dev dark theme is active the custom properties already
+   provide the right values, so no extra overrides are needed in most cases.
+   The fallbacks above (#ffffff / #111111) are for the personal light theme.
+   Explicit dark-mode fallbacks via media query for system-dark users: */
+@media (prefers-color-scheme: dark) {
+  .ak-preview-card {
+    background: var(--bg-elevated, #1e1e2e);
+    color: var(--fg1, #e0e0e0);
+    box-shadow:
+      0 4px 20px rgba(0, 0, 0, 0.45),
+      0 1px 4px  rgba(0, 0, 0, 0.3);
+  }
+
+  .ak-preview-card__title  { color: var(--fg1, #e8e8f0); }
+  .ak-preview-card__author { color: var(--fg2, #aaaacc); }
+  .ak-preview-card__excerpt { color: var(--fg2, #9999bb); }
+  .ak-preview-card__meta   { color: var(--fg3, #777799); }
+  .ak-preview-card__source { color: var(--fg3, #666688); }
+}

--- a/shared/previews.js
+++ b/shared/previews.js
@@ -1,0 +1,306 @@
+/**
+ * shared/previews.js — build-time link/image preview cards (IIFE, no deps).
+ * Add to pages:  <script src="/shared/previews.js" defer></script>
+ */
+(function () {
+  "use strict";
+
+  // ─── State ───────────────────────────────────────────────────────────────
+  var annotations = null;   // url -> record  (null = not yet loaded)
+  var card        = null;   // the floating card DOM node
+  var hideTimer   = null;
+  var showTimer   = null;
+  var activeAnchor = null;
+
+  var DEBOUNCE_MS  = 150;
+  var HIDE_GRACE_MS = 200;
+
+  // ─── Boot ─────────────────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", function () {
+    fetch("/annotations.json")
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (!data) return;
+        annotations = data;
+        attachPreviews();
+        // SPA: re-scan when the rich app swaps article content into #root.
+        var root = document.getElementById("root");
+        if (root) {
+          var t;
+          new MutationObserver(function () {
+            clearTimeout(t);
+            t = setTimeout(attachPreviews, 150);
+          }).observe(root, { childList: true, subtree: true });
+        }
+      })
+      .catch(function () { /* previews are pure enhancement */ });
+  });
+
+  // ─── Card creation ────────────────────────────────────────────────────────
+  function createCard() {
+    var el = document.createElement("div");
+    el.className = "ak-preview-card";
+    el.setAttribute("role", "tooltip");
+    el.setAttribute("aria-live", "polite");
+    el.addEventListener("mouseenter", function () { cancelHide(); });
+    el.addEventListener("mouseleave", function () { scheduleHide(); });
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function getCard() {
+    if (!card) card = createCard();
+    return card;
+  }
+
+  // ─── Card content builders ────────────────────────────────────────────────
+
+  function esc(str) {
+    return String(str || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function thumbHtml(src) {
+    if (!src) return "";
+    return '<img class="ak-preview-card__thumb" src="' + esc(src) + '" alt="" loading="lazy"/>';
+  }
+
+  function sourceLineHtml(url) {
+    try {
+      var host = new URL(url).hostname.replace(/^www\./, "");
+      return '<div class="ak-preview-card__source">' + esc(host) + '</div>';
+    } catch (e) { return ""; }
+  }
+
+  function buildCardHtml(record) {
+    var t = record.type;
+
+    if (t === "image") {
+      return (
+        '<div class="ak-preview-card--image">' +
+        '<img src="' + esc(record.src || record.url) + '" alt="' + esc(record.title || "") + '" loading="lazy"/>' +
+        (record.title ? '<div class="ak-preview-card__caption">' + esc(record.title) + '</div>' : '') +
+        '</div>'
+      );
+    }
+
+    var html = "";
+
+    if (t === "post") {
+      html += '<div class="ak-preview-card__type ak-preview-card__type--post">post</div>';
+    } else if (t === "wikipedia") {
+      html += '<div class="ak-preview-card__type ak-preview-card__type--wiki">Wikipedia</div>';
+    } else if (t === "arxiv") {
+      html += '<div class="ak-preview-card__type ak-preview-card__type--arxiv">arXiv</div>';
+    } else if (t === "file") {
+      html += '<div class="ak-preview-card__type ak-preview-card__type--file">' + esc((record.ext || "file").toUpperCase()) + '</div>';
+    }
+
+    if (record.thumb) html += thumbHtml(record.thumb);
+
+    if (record.title) {
+      html += '<div class="ak-preview-card__title">' + esc(record.title) + '</div>';
+    }
+
+    if (t === "arxiv" && record.author) {
+      html += '<div class="ak-preview-card__author">' + esc(record.author) + '</div>';
+    }
+
+    if (record.excerpt) {
+      // truncate long excerpts
+      var excerpt = record.excerpt.length > 200 ? record.excerpt.slice(0, 200).trimEnd() + "…" : record.excerpt;
+      html += '<div class="ak-preview-card__excerpt">' + esc(excerpt) + '</div>';
+    }
+
+    if (t === "post") {
+      var meta = [record.date, record.read].filter(Boolean).join(" · ");
+      if (meta) html += '<div class="ak-preview-card__meta">' + esc(meta) + '</div>';
+      if (record.tags && record.tags.length) {
+        html += '<div class="ak-preview-card__tags">' + record.tags.map(function (tag) {
+          return '<span class="ak-preview-card__tag">' + esc(tag) + '</span>';
+        }).join(" ") + '</div>';
+      }
+    }
+
+    if (t !== "post") {
+      var source = record.source || record.url;
+      if (source) html += sourceLineHtml(source);
+    }
+
+    if (!html) {
+      html = '<div class="ak-preview-card__title">' + esc(record.url) + '</div>';
+    }
+
+    return html;
+  }
+
+  // ─── Positioning ──────────────────────────────────────────────────────────
+
+  function positionCard(cardEl, anchorEl) {
+    var rect   = anchorEl.getBoundingClientRect();
+    var cw     = cardEl.offsetWidth  || 360;
+    var ch     = cardEl.offsetHeight || 160;
+    var vw     = window.innerWidth;
+    var vh     = window.innerHeight;
+    var GAP    = 8;
+    var scrollX = window.scrollX || window.pageXOffset;
+    var scrollY = window.scrollY || window.pageYOffset;
+
+    // Horizontal: align to anchor left, clamp to viewport
+    var left = rect.left + scrollX;
+    if (left + cw > scrollX + vw - GAP) left = scrollX + vw - cw - GAP;
+    if (left < scrollX + GAP) left = scrollX + GAP;
+
+    // Vertical: prefer below anchor; flip above if not enough space
+    var top;
+    if (rect.bottom + GAP + ch <= vh) {
+      top = rect.bottom + scrollY + GAP;
+    } else {
+      top = rect.top + scrollY - ch - GAP;
+    }
+    if (top < scrollY + GAP) top = scrollY + GAP;
+
+    cardEl.style.left = left + "px";
+    cardEl.style.top  = top  + "px";
+  }
+
+  // ─── Show / hide ──────────────────────────────────────────────────────────
+
+  function showCard(anchorEl, record) {
+    var c = getCard();
+    c.innerHTML = buildCardHtml(record);
+    c.className = "ak-preview-card" + (record.type === "image" ? " ak-preview-card--image-zoom" : "");
+    c.style.display = "block";
+    positionCard(c, anchorEl);
+    activeAnchor = anchorEl;
+  }
+
+  function hideCard() {
+    if (card) {
+      card.style.display = "none";
+      card.innerHTML = "";
+    }
+    activeAnchor = null;
+  }
+
+  function scheduleHide() {
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(hideCard, HIDE_GRACE_MS);
+  }
+
+  function cancelHide() {
+    clearTimeout(hideTimer);
+  }
+
+  // ─── Attach handlers ──────────────────────────────────────────────────────
+
+  function getRecord(url) {
+    if (!annotations) return null;
+    if (annotations[url]) return annotations[url];
+    // also try normalised form (strip trailing slash, fragment)
+    try {
+      var u = new URL(url, location.href);
+      var norm = u.href;
+      if (annotations[norm]) return annotations[norm];
+      // strip fragment
+      u.hash = "";
+      if (annotations[u.href]) return annotations[u.href];
+    } catch (e) {}
+    return null;
+  }
+
+  function attachAnchor(a) {
+    var href = a.getAttribute("href");
+    if (!href) return;
+    var record = getRecord(href);
+    if (!record) return;
+    if (a.dataset.akp) return;     // already attached (SPA re-scan guard)
+    a.dataset.akp = "1";
+    a.classList.add("has-preview");
+    a.setAttribute("aria-describedby", "ak-preview-card");
+
+    a.addEventListener("mouseenter", function () {
+      clearTimeout(showTimer);
+      showTimer = setTimeout(function () { showCard(a, record); }, DEBOUNCE_MS);
+    });
+    a.addEventListener("mouseleave", function () {
+      clearTimeout(showTimer);
+      scheduleHide();
+    });
+    a.addEventListener("focus", function () { showCard(a, record); });
+    a.addEventListener("blur",  function () { scheduleHide(); });
+  }
+
+  function attachImage(img) {
+    var src = img.getAttribute("src");
+    if (!src) return;
+    if (img.dataset.akp) return;   // already attached (SPA re-scan guard)
+    img.dataset.akp = "1";
+    // Build an image record on the fly (annotations.json may have one too)
+    var record = getRecord(src) || {
+      type: "image",
+      title: img.getAttribute("alt") || "",
+      src: src,
+      url: src,
+    };
+
+    img.style.cursor = "zoom-in";
+
+    var isMobile = false;
+
+    img.addEventListener("mouseenter", function () {
+      clearTimeout(showTimer);
+      if (!isMobile) {
+        showTimer = setTimeout(function () { showCard(img, record); }, DEBOUNCE_MS);
+      }
+    });
+    img.addEventListener("mouseleave", function () {
+      clearTimeout(showTimer);
+      scheduleHide();
+    });
+    img.addEventListener("click", function (e) {
+      // on touch-capable devices use click to toggle
+      e.preventDefault();
+      if (activeAnchor === img) {
+        hideCard();
+      } else {
+        showCard(img, record);
+      }
+    });
+  }
+
+  function attachPreviews() {
+    // Anchor links
+    var anchors = document.querySelectorAll("a[href]");
+    for (var i = 0; i < anchors.length; i++) attachAnchor(anchors[i]);
+
+    // Images inside .prose
+    var proseImages = document.querySelectorAll(".prose img");
+    for (var j = 0; j < proseImages.length; j++) attachImage(proseImages[j]);
+  }
+
+  // ─── Global dismiss ───────────────────────────────────────────────────────
+
+  document.addEventListener("scroll", function () { hideCard(); }, { passive: true });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") hideCard();
+  });
+  document.addEventListener("click", function (e) {
+    if (card && card.style.display !== "none") {
+      if (!card.contains(e.target) && e.target !== activeAnchor) {
+        hideCard();
+      }
+    }
+  });
+
+  // ─── Debug handle ─────────────────────────────────────────────────────────
+  window.AKPreviews = {
+    getAnnotations: function () { return annotations; },
+    showCard: showCard,
+    hideCard: hideCard,
+  };
+
+}());

--- a/shared/sidenotes.css
+++ b/shared/sidenotes.css
@@ -1,0 +1,55 @@
+/* Sidenotes — margin notes on wide screens, plain bottom-footnotes otherwise (see shared/sidenotes.js).
+   Degrades fully: with JS off, none of the .has-sidenotes class is applied, so the bottom <section
+   data-footnotes> shows as a normal footnotes list. */
+
+/* The article column must be a positioning context so absolute sidenotes anchor to it. */
+.prose { position: relative; }
+
+/* Footnote reference markers (marked-footnote: <sup><a data-footnote-ref>). */
+.prose a[data-footnote-ref] {
+  text-decoration: none;
+  font-variant-numeric: normal;
+  padding: 0 0.1em;
+  color: var(--accent, #2563eb);
+  font-weight: 600;
+}
+.prose a[data-footnote-ref]:hover { text-decoration: underline; }
+
+/* Floated margin sidenote. */
+.prose aside.sidenote {
+  position: absolute;
+  left: 100%;
+  width: 240px;
+  margin-left: 2rem;
+  font-family: var(--font-body, inherit);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--fg2, #555);
+}
+.prose aside.sidenote p { margin: 0 0 0.5em; }
+.prose aside.sidenote p:last-child { margin-bottom: 0; }
+.prose aside.sidenote .sidenote-num {
+  color: var(--accent, #2563eb);
+  font-weight: 700;
+  font-variant-numeric: normal;
+}
+.prose aside.sidenote a { color: var(--accent, #2563eb); }
+
+/* When sidenotes are active, hide the bottom footnotes list (it's been mirrored into the margin). */
+.prose.has-sidenotes section[data-footnotes] { display: none; }
+
+/* Bottom footnotes list (shown when narrow / no-JS) — keep it tidy. */
+.prose section[data-footnotes] {
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border, rgba(127, 127, 127, 0.25));
+  font-size: 0.9rem;
+}
+.prose section[data-footnotes] .sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prose aside.sidenote { transition: none; }
+}

--- a/shared/sidenotes.js
+++ b/shared/sidenotes.js
@@ -1,0 +1,68 @@
+/* sidenotes.js — progressive-enhancement margin sidenotes for marked-footnote output.
+
+   Pattern (Tufte / R. Nystrom, the same idea gwern's sidenotes.js is built on, minus gwern's
+   GW/Pandoc coupling): footnotes render normally at the bottom of the article (works with JS off /
+   on narrow screens). When the viewport is wide enough that there's real room in the right gutter,
+   we float each footnote into the margin next to its reference and hide the bottom list. Reflows on
+   resize; re-runs when the SPA swaps article content. Targets marked-footnote's DOM:
+     ref:  <sup><a data-footnote-ref id="footnote-ref-N" href="#footnote-N">N</a></sup>
+     body: <section data-footnotes><ol><li id="footnote-N"><p>… <a data-footnote-backref>↩</a></p></li></ol></section>
+*/
+(function () {
+  var MIN_VIEWPORT = 1200;   // below this: leave footnotes inline at the bottom
+  var GUTTER_MIN = 260;      // px of right-margin room required to float sidenotes
+  var SIDENOTE_W = 240;      // px
+  var GAP = 14;              // px min vertical gap between stacked sidenotes
+  var raf, timer;
+
+  function layout(prose) {
+    var section = prose.querySelector("section[data-footnotes]");
+    prose.querySelectorAll("aside.sidenote").forEach(function (n) { n.remove(); });
+    prose.classList.remove("has-sidenotes");
+    if (!section) return;
+
+    var rect = prose.getBoundingClientRect();
+    var rightRoom = window.innerWidth - rect.right;
+    if (window.innerWidth < MIN_VIEWPORT || rightRoom < GUTTER_MIN) return; // keep bottom footnotes
+
+    prose.classList.add("has-sidenotes");
+    var items = section.querySelectorAll("ol > li");
+    var prevBottom = 0;
+    items.forEach(function (li) {
+      var ref = prose.querySelector('a[data-footnote-ref][href="#' + li.id + '"]');
+      if (!ref) return;
+      var clone = li.cloneNode(true);
+      clone.querySelectorAll("[data-footnote-backref]").forEach(function (b) { b.remove(); });
+      var aside = document.createElement("aside");
+      aside.className = "sidenote";
+      aside.innerHTML = '<span class="sidenote-num">' + (ref.textContent || "") + "</span> " + clone.innerHTML.trim();
+      prose.appendChild(aside);
+      // align top with the reference (relative to the positioned .prose), avoiding overlap
+      var refTop = ref.getBoundingClientRect().top - rect.top;
+      var top = Math.max(refTop, prevBottom + GAP);
+      aside.style.top = top + "px";
+      prevBottom = top + aside.offsetHeight;
+    });
+  }
+
+  function relayout() {
+    if (observer) observer.disconnect();
+    document.querySelectorAll(".prose").forEach(layout);
+    if (observer) observe();
+  }
+  function schedule() { cancelAnimationFrame(raf); raf = requestAnimationFrame(relayout); }
+  function scheduleDebounced() { clearTimeout(timer); timer = setTimeout(schedule, 150); }
+
+  // SPA: the rich app mounts articles into #root after load — re-run when that subtree changes.
+  var root = document.getElementById("root");
+  var observer = root ? new MutationObserver(scheduleDebounced) : null;
+  function observe() { if (observer) observer.observe(root, { childList: true, subtree: true }); }
+
+  window.addEventListener("resize", schedule);
+  window.addEventListener("load", schedule);
+  if (document.readyState !== "loading") schedule();
+  else document.addEventListener("DOMContentLoaded", schedule);
+  observe();
+
+  window.AKSidenotes = { refresh: schedule };
+})();


### PR DESCRIPTION
## What

Phase 2 of the gwern-inspired reading features. Both are **progressive enhancement** — everything degrades to plain bottom-footnotes and plain links/images with JS off, on narrow screens, or in plain mode.

### Sidenotes
- Author footnotes as Markdown `[^n]` (`marked-footnote`, registered in both the Node build and the browser).
- On wide viewports with real gutter room, each note floats into the **right margin** next to its reference; narrow/no-JS keeps the normal **bottom-footnotes** list.
- `shared/sidenotes.{js,css}` — a self-contained Tufte/Nystrom implementation. gwern's own `sidenotes.js` turned out coupled to its ~900 KB `GW`/Pandoc engine (a `Notes` model, `#sidenote-column` layout, a 1761px-wide design), so per the new **don't-reinvent-the-wheel** skill we reused the *pattern*, not the bespoke file.

### Previews
- `scripts/annotations.mjs` resolves link/image metadata **at build time** into `annotations.json`: internal posts (from `posts.json`), **Wikipedia** (REST API), **arXiv** (API), PDFs/files, images, and an **OpenGraph** fallback. Cached in `data/annotations.cache.json` so CI doesn't refetch.
- `shared/previews.{js,css}` shows hover/tap **cards** + **image zoom**; links/images remain fully functional without it.
- **No Git LFS / external storage** — previews are compact text metadata in-repo (Pages doesn't serve LFS).

### Images
- Posts support `![alt](…)`; `posts/<side>/img/` is copied to `_public/<side>/img/`.

### Demo
- One demo post per side (footnotes + internal/Wikipedia/arXiv links + image) as the end-to-end fixture.

## Verified (headless)
- Static post: **margin sidenotes** wide → **bottom footnotes** narrow.
- SPA article: footnotes + sidenotes render (browser `marked-footnote` + MutationObserver re-enhance).
- Preview cards resolve for arXiv ("Attention Is All You Need" + authors), Wikipedia, and internal posts; image zooms.

## Deferred (unchanged)
- Phase 3 `gwtar` + external object storage for archived originals — to revisit after this lands.
- Dropping in-browser Babel (Phase 1 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)