### PR TITLE
Fix sidenotes (two-margin) + land drafts, snapshot cache, acknowledgements

### DIFF
--- a/posts/dev/2026-06-10-sidenotes-and-previews.md
+++ b/posts/dev/2026-06-10-sidenotes-and-previews.md
@@ -9,9 +9,15 @@ featured: true
 
 This post exists to exercise the reading machinery: margin **sidenotes**, hover **previews**, and embedded images. None of it is required to read the words — that's the whole point.[^why]
 
-Sidenotes are the good kind of footnote. On a wide screen the note floats into the margin next to its reference, so you can read it without losing your place.[^tufte] On a narrow screen, or with JavaScript off, the same note simply appears at the bottom as an ordinary footnote.[^degrade]
+Sidenotes are the good kind of footnote. On a wide screen the note floats into the margin next to its reference, so you can read it without losing your place. They borrow both margins — left and right — so several notes in the same passage can each sit beside their own mention instead of piling up in a single column.
 
-Hover previews are compiled at build time, not fetched live. A link to [the Wikipedia article on hypertext](https://en.wikipedia.org/wiki/Hypertext) carries a small card; so does a paper like [Attention Is All You Need](https://arxiv.org/abs/1706.03762). Internal links — say, [the quiet demo on the other side](/personal/p/a-quiet-demo/) — pull their card straight from the post index.
+The idea is old. Edward Tufte popularized it for the web, and gwern.net refined the mechanics: notes that reflow as the window changes, and collapse gracefully when the screen is too narrow to spare a margin.[^tufte]
+
+On a narrow screen, or with JavaScript off, the very same notes simply appear at the bottom as ordinary footnotes — nothing is lost, and a 1999 browser renders it fine.[^degrade]
+
+Hover previews are a separate idea, and they're compiled at build time rather than fetched live. A link to [the Wikipedia article on hypertext](https://en.wikipedia.org/wiki/Hypertext) carries a small card; so does a paper like [Attention Is All You Need](https://arxiv.org/abs/1706.03762).
+
+Internal links — say, [the quiet demo on the other side](/personal/p/a-quiet-demo/) — pull their card straight from the post index, with no network round-trip at all.[^build]
 
 Images work too, and zoom on hover:
 
@@ -22,3 +28,4 @@ That's the whole demo. Delete this file whenever real posts arrive.
 [^why]: Progressive enhancement: the page is readable first, and the niceties layer on top only where the browser and viewport allow.
 [^tufte]: The pattern is Edward Tufte's, popularized in Tufte-CSS and adapted by gwern.net.
 [^degrade]: This footnote is proof — resize the window narrow (or disable JS) and watch it slide back to the bottom of the article.
+[^build]: The preview metadata for internal links comes straight from `posts.json`; external links (Wikipedia, arXiv) are resolved once at build time and cached, so the published pages stay fast.

--- a/shared/sidenotes.css
+++ b/shared/sidenotes.css
@@ -26,6 +26,14 @@
   line-height: 1.5;
   color: var(--fg2, #555);
 }
+/* Left-margin column: mirror to the left of the text, hugging the column edge (gwern-style). */
+.prose aside.sidenote--left {
+  left: auto;
+  right: 100%;
+  margin-left: 0;
+  margin-right: 2rem;
+  text-align: right;
+}
 .prose aside.sidenote p { margin: 0 0 0.5em; }
 .prose aside.sidenote p:last-child { margin-bottom: 0; }
 .prose aside.sidenote .sidenote-num {

--- a/shared/sidenotes.css
+++ b/shared/sidenotes.css
@@ -5,6 +5,10 @@
 /* The article column must be a positioning context so absolute sidenotes anchor to it. */
 .prose { position: relative; }
 
+/* Constrain article images to the text column — never wider than the article (static pages + both
+   SPA article contexts all use .prose, and this file is loaded in all of them). */
+.prose img { max-width: 100%; height: auto; }
+
 /* Footnote reference markers (marked-footnote: <sup><a data-footnote-ref>). */
 .prose a[data-footnote-ref] {
   text-decoration: none;

--- a/shared/sidenotes.js
+++ b/shared/sidenotes.js
@@ -1,19 +1,30 @@
-/* sidenotes.js — progressive-enhancement margin sidenotes for marked-footnote output.
+/* sidenotes.js — two-column margin sidenotes for marked-footnote output (progressive enhancement).
 
-   Pattern (Tufte / R. Nystrom, the same idea gwern's sidenotes.js is built on, minus gwern's
-   GW/Pandoc coupling): footnotes render normally at the bottom of the article (works with JS off /
-   on narrow screens). When the viewport is wide enough that there's real room in the right gutter,
-   we float each footnote into the margin next to its reference and hide the bottom list. Reflows on
-   resize; re-runs when the SPA swaps article content. Targets marked-footnote's DOM:
+   The behaviour follows gwern.net's sidenotes (gwern.net/sidenote, after Tufte-CSS): each footnote is
+   placed in the page margin *next to its reference*. Gwern's own sidenotes.js is a ~1300-line engine
+   fused to its Notes model / transclude / page-toolbar / hash-routing, so this is a small self-contained
+   implementation of the part that matters — the key trick we were missing is using BOTH margins, which
+   lets clustered references each sit beside their mention instead of stacking in one column.
+
+   Degrades fully: with JS off, on narrow screens, or when there isn't gutter room, the footnotes stay a
+   normal <section data-footnotes> list at the bottom. Targets marked-footnote's DOM:
      ref:  <sup><a data-footnote-ref id="footnote-ref-N" href="#footnote-N">N</a></sup>
      body: <section data-footnotes><ol><li id="footnote-N"><p>… <a data-footnote-backref>↩</a></p></li></ol></section>
 */
 (function () {
-  var MIN_VIEWPORT = 1200;   // below this: leave footnotes inline at the bottom
-  var GUTTER_MIN = 260;      // px of right-margin room required to float sidenotes
-  var SIDENOTE_W = 240;      // px
-  var GAP = 14;              // px min vertical gap between stacked sidenotes
-  var raf, timer;
+  var MIN_VIEWPORT = 1000;  // below this: leave footnotes inline at the bottom
+  var GUTTER_MIN = 230;     // px of margin room required for a sidenote column
+  var GAP = 16;             // px min vertical gap between stacked sidenotes in a column
+  var raf, timer, observer;
+
+  function buildAside(li, ref, side) {
+    var clone = li.cloneNode(true);
+    clone.querySelectorAll("[data-footnote-backref]").forEach(function (b) { b.remove(); });
+    var aside = document.createElement("aside");
+    aside.className = "sidenote" + (side === "left" ? " sidenote--left" : "");
+    aside.innerHTML = '<span class="sidenote-num">' + (ref.textContent || "") + "</span> " + clone.innerHTML.trim();
+    return aside;
+  }
 
   function layout(prose) {
     var section = prose.querySelector("section[data-footnotes]");
@@ -23,39 +34,42 @@
 
     var rect = prose.getBoundingClientRect();
     var rightRoom = window.innerWidth - rect.right;
-    if (window.innerWidth < MIN_VIEWPORT || rightRoom < GUTTER_MIN) return; // keep bottom footnotes
+    var leftRoom = rect.left;
+    var canRight = rightRoom >= GUTTER_MIN;
+    var canLeft = leftRoom >= GUTTER_MIN;
+    if (window.innerWidth < MIN_VIEWPORT || (!canRight && !canLeft)) return; // keep bottom footnotes
 
     prose.classList.add("has-sidenotes");
+    var twoCol = canLeft && canRight;
+    var bottom = { left: 0, right: 0 };           // running bottom of each column (for collision)
     var items = section.querySelectorAll("ol > li");
-    var prevBottom = 0;
+    var i = 0;
     items.forEach(function (li) {
       var ref = prose.querySelector('a[data-footnote-ref][href="#' + li.id + '"]');
       if (!ref) return;
-      var clone = li.cloneNode(true);
-      clone.querySelectorAll("[data-footnote-backref]").forEach(function (b) { b.remove(); });
-      var aside = document.createElement("aside");
-      aside.className = "sidenote";
-      aside.innerHTML = '<span class="sidenote-num">' + (ref.textContent || "") + "</span> " + clone.innerHTML.trim();
+      // Alternate columns when both margins are available; otherwise use whichever has room.
+      var side = !canLeft ? "right" : !canRight ? "left" : (i % 2 === 0 ? "right" : "left");
+      var aside = buildAside(li, ref, side);
       prose.appendChild(aside);
-      // align top with the reference (relative to the positioned .prose), avoiding overlap
-      var refTop = ref.getBoundingClientRect().top - rect.top;
-      var top = Math.max(refTop, prevBottom + GAP);
+      var refTop = ref.getBoundingClientRect().top - rect.top;     // align to the reference
+      var top = Math.max(refTop, bottom[side] + GAP);              // …but never overlap the prior note
       aside.style.top = top + "px";
-      prevBottom = top + aside.offsetHeight;
+      bottom[side] = top + aside.offsetHeight;
+      i++;
     });
   }
 
   function relayout() {
     if (observer) observer.disconnect();
     document.querySelectorAll(".prose").forEach(layout);
-    if (observer) observe();
+    observe();
   }
   function schedule() { cancelAnimationFrame(raf); raf = requestAnimationFrame(relayout); }
   function scheduleDebounced() { clearTimeout(timer); timer = setTimeout(schedule, 150); }
 
   // SPA: the rich app mounts articles into #root after load — re-run when that subtree changes.
   var root = document.getElementById("root");
-  var observer = root ? new MutationObserver(scheduleDebounced) : null;
+  observer = root ? new MutationObserver(scheduleDebounced) : null;
   function observe() { if (observer) observer.observe(root, { childList: true, subtree: true }); }
 
   window.addEventListener("resize", schedule);


### PR DESCRIPTION
Bundles the work pushed after PR #2's squash-merge plus the sidenotes fix you flagged.

## Fix: sidenotes sit beside their references
The single-column layout stacked clustered footnotes in the right margin, so only the first lined up with its mention. Now uses **both margins** (gwern's key trick): notes alternate left/right, each aligned to its reference, colliding only within a column; left-column notes are right-aligned to hug the text. Degrades to bottom-footnotes when narrow (<1000px) / no-JS.

> Note on "use gwern's sidenotes.js": I read it in full — it's a ~1300-line engine fused to gwern's `Notes` model, `transclude`, page-toolbar, and hash-routing, so it isn't cleanly vendorable. Per the don't-reinvent-the-wheel skill, this reuses the *two-margin pattern*, not the file (credited on the acknowledgements page).

**Verified (headless; deployed JS is byte-identical to local):** wide 1600 & 1200 → notes beside refs across both margins; SPA article → same; narrow 820 → bottom footnotes; real `mouseenter` → preview card shows.

## Also lands (was unmerged after PR #2)
- **Drafts:** `draft: true` front-matter excludes a post; `npm run build:drafts` (`DRAFTS=1`) includes them for preview.
- **Snapshot cache + bench:** dev-hub repos/stats cached in `data/snapshot.cache.json` → warm builds ~0.14s (cold ~4s); `npm run build:refresh` to update, `--no-fetch` offline; `npm run bench`.
- **Acknowledgements page** at `/acknowledgements/` crediting gwern.net (sidenotes pattern, popups/previews UX, philosophy, gwtar), Tufte-CSS, marked/marked-footnote, esbuild, etc.; linked from all footers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)