### PR TITLE
feat(dev): private-aware project rendering for case studies

### DIFF
--- a/dev/Shared.jsx
+++ b/dev/Shared.jsx
@@ -18,15 +18,20 @@ function StatTiles({ stats }) {
 
 function RepoCard({ repo }) {
   return (
-    <div className="dh-repo">
-      <a className="name" href={repo.url} target="_blank" rel="noopener">{repo.name}</a>
+    <div className={"dh-repo" + (repo.priv ? " is-private" : "")}>
+      {repo.url
+        ? <a className="name" href={repo.url} target="_blank" rel="noopener">{repo.name}</a>
+        : <span className="name">{repo.name}</span>}
+      {repo.priv && <span className="client-tag">{repo.client ? "client work" : "private"}</span>}
       <p className="desc">{repo.desc}</p>
       {repo.tags && repo.tags.length > 0 &&
         <div className="tags">{repo.tags.map(t => <span className="tag" key={t}>{t}</span>)}</div>}
       <div className="meta">
         {repo.lang && <span className="lang"><span className="dot" style={{ background: `var(${repo.langVar})` }}></span>{repo.lang}</span>}
         {repo.docs && <a className="docs" href={repo.docs} target="_blank" rel="noopener">docs ↗</a>}
-        <a className="repo" href={repo.url} target="_blank" rel="noopener">code ↗</a>
+        {repo.repo
+          ? <a className="repo" href={repo.repo} target="_blank" rel="noopener">code ↗</a>
+          : (repo.writeup && <a className="repo" href={repo.writeup} target="_blank" rel="noopener">case study ↗</a>)}
       </div>
     </div>
   );

--- a/dev/app.jsx
+++ b/dev/app.jsx
@@ -66,7 +66,9 @@ function App() {
     fetch(PROJECTS_URL).then(r => r.json()).then(d => setRepos((d.projects || []).map(p => ({
       name: p.name, desc: p.description || "", tags: (p.keywords || []).slice(0, 3),
       lang: p.language || "", langVar: LANG_VAR[p.language] || "--lang-other",
-      url: p.repo, docs: p.docs || "",
+      // private client work has no public repo — link the title to the write-up/docs instead
+      url: p.repo || p.writeup || p.docs || "", repo: p.repo || "", docs: p.docs || "",
+      writeup: p.writeup || "", priv: (p.source === "private"), client: p.client || "",
     })))).catch(() => {});
 
     // Live GitHub metrics — repos/stars/followers/age + language split + repos-per-year.

--- a/dev/blocks.mjs
+++ b/dev/blocks.mjs
@@ -24,7 +24,7 @@ export function devBlocks({ route, posts = [], repos = [], stats = [], current, 
     { t: "grid", cols: 4, cells: (stats || []).map(s => ({ title: s.num, lines: [s.ico, s.cap] })) },
     { t: "h2", text: "Pinned repos" },
     // 3-up grid of repo tiles, like the rich grid.
-    { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : [])] })) },
+    { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, r.priv ? (r.client ? "client work" : "private") : r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : []), ...((!r.repo && r.writeup) ? [{ text: "case study ↗", href: r.writeup }] : [])] })) },
   ];
   if (posts.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["post", "date"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date]) });
   const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);

--- a/dev/styles.css
+++ b/dev/styles.css
@@ -187,6 +187,10 @@ body { margin: 0; background: var(--bg); color: var(--fg1); font-family: var(--f
 .dh-repo .meta { display: flex; gap: 14px; align-items: center; font-family: var(--font-mono); font-size: 12px; color: var(--fg3); }
 .dh-repo .lang { display: flex; align-items: center; gap: 6px; }
 .dh-repo .dot { width: 10px; height: 10px; border-radius: 999px; }
+/* private client work (case study, no public repo) */
+.dh-repo.is-private { border-color: var(--accent-2); }
+.dh-repo .client-tag { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--accent-2); background: var(--accent-2-soft); border-radius: 999px; padding: 2px 8px; align-self: flex-start; }
+.dh-repo span.name { font-family: var(--font-mono); font-size: 14px; color: var(--accent); font-weight: 600; }
 
 /* ---------- Data panel ---------- */
 .dh-data { display: grid; grid-template-columns: 1.3fr 1fr; gap: 16px; }

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -2,7 +2,8 @@
 /* ============================================================
    build-index.mjs — scan posts/{dev,personal}/*.md and write posts.json.
    Folder = side. Front-matter (between --- lines): title, date (YYYY-MM-DD),
-   tags [a, b], blurb, read, featured. Slug = filename minus date prefix + .md.
+   tags [a, b], blurb, read, featured, type ("case-study" for client write-ups).
+   Slug = filename minus date prefix + .md.
    No dependencies (Node 18+). Run: `node scripts/build-index.mjs`.
    ============================================================ */
 import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
@@ -58,6 +59,7 @@ function collect(repo, side) {
         read: fm.read || "",
         featured: fm.featured === "true",
         draft: fm.draft === "true",
+        type: fm.type || "post",            // "case-study" for client write-ups; "post" otherwise
         path: `posts/${side}/${f}`,
       };
     })

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -85,7 +85,10 @@ async function fetchSnapshot(dh) {
   try {
     const d = await (await fetch(PROJECTS_URL)).json();
     repos = (d.projects || []).map(p => ({
-      name: p.name, desc: p.description || "", lang: p.language || "", url: p.repo, docs: p.docs || "",
+      name: p.name, desc: p.description || "", lang: p.language || "",
+      // private client work has no public repo — fall back to write-up/docs for the no-JS baseline
+      url: p.repo || p.writeup || p.docs || "", repo: p.repo || "", docs: p.docs || "",
+      writeup: p.writeup || "", priv: (p.source === "private"), client: p.client || "",
     }));
   } catch (e) { log("repos fetch failed, baseline omits pinned repos:", e.message); }
 


### PR DESCRIPTION
The dev hub reads the portfolio's `data/projects.json` and assumed every project has a public GitHub `repo`. The portfolio now also carries **private client case studies** (`source:"private"`, no `repo`). This makes the dev side render them correctly instead of emitting dead links.

## Changes
- **`dev/app.jsx` / `dev/Shared.jsx`** — `RepoCard` is now repo-optional: the title falls back to the write-up/docs link (plain text if none), shows a `client work` / `private` tag, and renders a `case study ↗` link instead of a dead `code ↗` when there's no public repo.
- **`dev/blocks.mjs` / `scripts/build.mjs`** — same fallbacks in the no-JS baseline snapshot (title href + line + case-study link), so the static baseline never emits broken hrefs.
- **`scripts/build-index.mjs`** — emits a `type` field (e.g. `case-study`) from post front-matter, defaulting to `post`.
- **`dev/styles.css`** — styling for the private/client tag.

## Context
Single source of truth is `portfolio/data/projects.json` (already merged + live on the portfolio side). Private entries are skipped by the portfolio's `refresh.mjs`, so the GitHub auto-refresh never touches them.

## Verification
- No-JS baseline IR unit test: private cell falls back to write-up, shows `client work`/`private`, case-study link, no broken hrefs.
- Offline build (`NO_FETCH=1 node scripts/build.mjs`) clean; `app.jsx`/`Shared.jsx` parse under Babel react preset.
- Live render of the portfolio with the 7 seeded case studies: 0 broken hrefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)