### PR TITLE
feat(dev): color-code projects by category on the dev hub

### DIFF
--- a/dev/Shared.jsx
+++ b/dev/Shared.jsx
@@ -18,11 +18,13 @@ function StatTiles({ stats }) {
 
 function RepoCard({ repo }) {
   return (
-    <div className={"dh-repo" + (repo.priv ? " is-private" : "")}>
+    <div className={"dh-repo" + (repo.priv ? " is-private" : "")} data-category={repo.category || ""}
+         style={{ "--cat-color": `var(${repo.catVar || "--accent"})` }}>
       {repo.url
         ? <a className="name" href={repo.url} target="_blank" rel="noopener">{repo.name}</a>
         : <span className="name">{repo.name}</span>}
       {repo.priv && <span className="client-tag">{repo.client ? "client work" : "private"}</span>}
+      {repo.category && <span className="cat-chip"><span className="cat-dot"></span>{repo.category}</span>}
       <p className="desc">{repo.desc}</p>
       {repo.tags && repo.tags.length > 0 &&
         <div className="tags">{repo.tags.map(t => <span className="tag" key={t}>{t}</span>)}</div>}

--- a/dev/app.jsx
+++ b/dev/app.jsx
@@ -7,6 +7,12 @@ const LANG_VAR = {
   JavaScript: "--lang-js", TypeScript: "--lang-ts", Python: "--lang-py", Rust: "--lang-rust",
   Go: "--lang-go", CSS: "--lang-css", HTML: "--lang-css", Shell: "--lang-shell", "Jupyter Notebook": "--lang-py",
 };
+// Project category -> ak-design categorical palette token (--viz-1..8, same in both themes).
+// Keep in sync with the portfolio's CATEGORY_VAR (portfolio/app.js). Unmapped -> --accent.
+const CATEGORY_VAR = {
+  "AI Agents & LLMs": "--viz-1", "ML & Modeling": "--viz-2", "Computer Vision / Document AI": "--viz-5",
+  "MLOps & Templates": "--viz-4", "Developer Tools": "--viz-6", "Creative AI": "--viz-7",
+};
 const VIZ = ["--viz-1", "--viz-2", "--viz-3", "--viz-4", "--viz-5", "--viz-6", "--viz-7", "--viz-8"];
 const USER = "arslankazmi";
 const PROJECTS_URL = "https://arslankazmi.github.io/portfolio/data/projects.json";
@@ -69,6 +75,7 @@ function App() {
       // private client work has no public repo — link the title to the write-up/docs instead
       url: p.repo || p.writeup || p.docs || "", repo: p.repo || "", docs: p.docs || "",
       writeup: p.writeup || "", priv: (p.source === "private"), client: p.client || "",
+      category: p.category || "", catVar: CATEGORY_VAR[p.category] || "--accent",
     })))).catch(() => {});
 
     // Live GitHub metrics — repos/stars/followers/age + language split + repos-per-year.

--- a/dev/blocks.mjs
+++ b/dev/blocks.mjs
@@ -24,7 +24,7 @@ export function devBlocks({ route, posts = [], repos = [], stats = [], current, 
     { t: "grid", cols: 4, cells: (stats || []).map(s => ({ title: s.num, lines: [s.ico, s.cap] })) },
     { t: "h2", text: "Pinned repos" },
     // 3-up grid of repo tiles, like the rich grid.
-    { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, r.priv ? (r.client ? "client work" : "private") : r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : []), ...((!r.repo && r.writeup) ? [{ text: "case study ↗", href: r.writeup }] : [])] })) },
+    { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, ...(r.category ? [r.category] : []), r.priv ? (r.client ? "client work" : "private") : r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : []), ...((!r.repo && r.writeup) ? [{ text: "case study ↗", href: r.writeup }] : [])] })) },
   ];
   if (posts.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["post", "date"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date]) });
   const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);

--- a/dev/styles.css
+++ b/dev/styles.css
@@ -174,7 +174,7 @@ body { margin: 0; background: var(--bg); color: var(--fg1); font-family: var(--f
 
 /* ---------- Repo grid ---------- */
 .dh-repos { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
-.dh-repo { background: var(--bg-elevated); border: 2px solid var(--ink-900); border-radius: 4px; padding: 16px 18px; display: flex; flex-direction: column; gap: 8px; cursor: pointer; box-shadow: 4px 4px 0 #000; transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out); }
+.dh-repo { background: var(--bg-elevated); border: 2px solid var(--ink-900); border-left: 5px solid var(--cat-color, var(--accent)); border-radius: 4px; padding: 16px 18px; display: flex; flex-direction: column; gap: 8px; cursor: pointer; box-shadow: 4px 4px 0 #000; transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out); }
 .dh-repo:hover { transform: translate(-2px,-2px); box-shadow: 6px 6px 0 #000; }
 .dh-repo .name { font-family: var(--font-mono); font-size: 14px; color: var(--accent); font-weight: 600; text-decoration: none; }
 .dh-repo .name:hover { text-decoration: underline; }
@@ -187,10 +187,14 @@ body { margin: 0; background: var(--bg); color: var(--fg1); font-family: var(--f
 .dh-repo .meta { display: flex; gap: 14px; align-items: center; font-family: var(--font-mono); font-size: 12px; color: var(--fg3); }
 .dh-repo .lang { display: flex; align-items: center; gap: 6px; }
 .dh-repo .dot { width: 10px; height: 10px; border-radius: 999px; }
-/* private client work (case study, no public repo) */
-.dh-repo.is-private { border-color: var(--accent-2); }
+/* private client work (case study, no public repo): dashed border as a STYLE cue, so the
+   category-coloured left stripe stays the dominant colour signal. */
+.dh-repo.is-private { border-top-style: dashed; border-right-style: dashed; border-bottom-style: dashed; }
 .dh-repo .client-tag { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--accent-2); background: var(--accent-2-soft); border-radius: 999px; padding: 2px 8px; align-self: flex-start; }
 .dh-repo span.name { font-family: var(--font-mono); font-size: 14px; color: var(--accent); font-weight: 600; }
+/* category colour chip (hue from ak-design --viz-* via --cat-color) */
+.dh-repo .cat-chip { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.03em; color: var(--fg3); align-self: flex-start; }
+.dh-repo .cat-dot { width: 8px; height: 8px; border-radius: 999px; background: var(--cat-color, var(--accent)); }
 
 /* ---------- Data panel ---------- */
 .dh-data { display: grid; grid-template-columns: 1.3fr 1fr; gap: 16px; }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -89,6 +89,7 @@ async function fetchSnapshot(dh) {
       // private client work has no public repo — fall back to write-up/docs for the no-JS baseline
       url: p.repo || p.writeup || p.docs || "", repo: p.repo || "", docs: p.docs || "",
       writeup: p.writeup || "", priv: (p.source === "private"), client: p.client || "",
+      category: p.category || "",
     }));
   } catch (e) { log("repos fetch failed, baseline omits pinned repos:", e.message); }
 


### PR DESCRIPTION
Color-codes projects by **category** on the dev hub, mirroring the same system just shipped on the portfolio, so the two stay visually consistent.

> Stacked on #4 (`feat/private-projects`) — it edits the same dev card files. GitHub will retarget this PR to `main` once #4 merges.

## Changes
- **`dev/app.jsx`** — `CATEGORY_VAR` map (matches `portfolio/app.js`); threads `category` + `catVar` through the projects mapping.
- **`dev/Shared.jsx`** — `RepoCard` gets a category-colored left stripe, a category chip, and `data-category`. Private/client stays a separate badge + dashed-border cue (doesn't compete with the category hue).
- **`scripts/build.mjs` / `dev/blocks.mjs`** — carry `category` into the no-JS baseline.
- **`dev/styles.css`** — `--cat-color` left border, `.cat-chip`/`.cat-dot`, private style cue.

## Design
Category hue comes from ak-design's `--viz-1..8` categorical palette (identical values in both themes) — no invented colors. Mapping: AI Agents→viz-1, ML & Modeling→viz-2, CV/Doc AI→viz-5, MLOps→viz-4, Dev Tools→viz-6, Creative AI→viz-7; unmapped → `var(--accent)`.

## Verification
- Offline build clean; `app.jsx`/`Shared.jsx` parse under Babel react preset; baseline IR carries `category`.
- Headless dev render: 18 category chips, all 6 `--viz` hues present, 7 private cards with the dashed cue.
- New CSS is 100% `var(--…)` tokens (only pre-existing hex is the neo-brutalist `box-shadow:#000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)