### PR TITLE
Hide the dev hub "On GitHub" stats section for now

### DIFF
--- a/dev/app.jsx
+++ b/dev/app.jsx
@@ -29,8 +29,9 @@ function HomeLayouts({ posts, repos, stats, onMore }) {
       {writing}
       <div className="dh-sec"><h2>Projects</h2><span className="hint">{repos.length} repos · <a href="../portfolio/">full catalog ↗</a></span></div>
       <RepoGrid repos={repos} />
+      {/* GitHub stats hidden for now — re-enable by uncommenting:
       <div className="dh-sec"><h2>On GitHub</h2><span className="hint">live · @{USER}</span></div>
-      <StatTiles stats={stats} />
+      <StatTiles stats={stats} /> */}
       <div className="dh-sec"><h2>Reading &amp; playing</h2></div>
       <ReadingPlaying />
       <OtherSide />

--- a/dev/blocks.mjs
+++ b/dev/blocks.mjs
@@ -26,9 +26,7 @@ export function devBlocks({ route, posts = [], repos = [], stats = [], current, 
     { t: "h2", text: "Projects" },
     // 3-up grid of repo tiles, like the rich grid.
     { t: "grid", cols: 3, cells: (repos || []).map(r => ({ title: r.name, href: r.url, lines: [r.desc, ...(r.category ? [r.category] : []), r.priv ? (r.client ? "client work" : "private") : r.lang, ...(r.docs ? [{ text: "docs ↗", href: r.docs }] : []), ...((!r.repo && r.writeup) ? [{ text: "case study ↗", href: r.writeup }] : [])] })) },
-    { t: "h2", text: "On GitHub" },
-    // 4 stat tiles across, like the rich row.
-    { t: "grid", cols: 4, cells: (stats || []).map(s => ({ title: s.num, lines: [s.ico, s.cap] })) },
+    // "On GitHub" stat tiles hidden for now — re-enable alongside the rich view's StatTiles.
   );
   const playLines = [now.ti, games.next ? `up next · ${games.next}` : null, games.again ? `replaying · ${games.again}` : null].filter(Boolean);
   b.push(


### PR DESCRIPTION
Hides the dev hub's "On GitHub" stat tiles in both the live React view and the no-JS baseline. The `StatTiles` component and the live GitHub fetch are left in place, so re-enabling is a one-line uncomment in `dev/app.jsx` (and the matching note in `dev/blocks.mjs`).

Dev hub home is now: Hero → Writing → Projects → Reading & playing.

> Recovered commit: this change was originally pushed onto `feat/blog-tweaks` *after* PR #7 merged, so it had stranded off `main`. Cherry-picked onto a fresh branch off the updated `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)