### PR TITLE
Add dev article with a dependency-free spinning ASCII asterisk

### DIFF
--- a/data/annotations.cache.json
+++ b/data/annotations.cache.json
@@ -49,5 +49,11 @@
     "title": "The Metroid Prime logo",
     "src": "/assets/metroid-prime.png",
     "url": "/assets/metroid-prime.png"
+  },
+  "https://www.a1k0n.net/2011/07/20/donut-math.html": {
+    "type": "link",
+    "title": "www.a1k0n.net",
+    "source": "www.a1k0n.net",
+    "url": "https://www.a1k0n.net/2011/07/20/donut-math.html"
   }
 }

--- a/dev/index.html
+++ b/dev/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="../shared/plain.css"/>
   <link rel="stylesheet" href="../shared/sidenotes.css"/>
   <link rel="stylesheet" href="../shared/previews.css"/>
+  <link rel="stylesheet" href="../shared/ascii-asterisk.css"/>
   <script>try{if(localStorage.getItem("ak-view")==="plain")document.documentElement.setAttribute("data-view","plain");}catch(e){}</script>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin></script>
@@ -38,5 +39,6 @@
   <script type="text/babel" src="app.jsx"></script>
   <script src="../shared/sidenotes.js" defer></script>
   <script src="../shared/previews.js" defer></script>
+  <script src="../shared/ascii-asterisk.js" defer></script>
 </body>
 </html>

--- a/posts.json
+++ b/posts.json
@@ -1,6 +1,26 @@
 {
   "dev": [
     {
+      "slug": "ascii-asterisk",
+      "side": "dev",
+      "title": "A spinning ASCII asterisk, no dependencies",
+      "date": "Jul 2026",
+      "dateLong": "Jul 6, 2026",
+      "iso": "2026-07-06",
+      "tags": [
+        "javascript",
+        "ascii-art",
+        "animation",
+        "graphics"
+      ],
+      "blurb": "A from-scratch 3D renderer — rotation matrices, perspective, a z-buffer, luminance shading — pointed at a six-point starburst and drawn entirely in text characters.",
+      "read": "5 min",
+      "featured": true,
+      "draft": false,
+      "type": "post",
+      "path": "posts/dev/2026-07-06-ascii-asterisk.md"
+    },
+    {
       "slug": "sidenotes-and-previews",
       "side": "dev",
       "title": "Sidenotes, previews, and other quiet machinery",
@@ -16,6 +36,7 @@
       "read": "4 min",
       "featured": true,
       "draft": false,
+      "type": "post",
       "path": "posts/dev/2026-06-10-sidenotes-and-previews.md"
     }
   ],
@@ -34,6 +55,7 @@
       "read": "3 min",
       "featured": false,
       "draft": false,
+      "type": "post",
       "path": "posts/personal/2026-06-10-a-quiet-demo.md"
     }
   ]

--- a/posts/dev/2026-07-06-ascii-asterisk.md
+++ b/posts/dev/2026-07-06-ascii-asterisk.md
@@ -1,0 +1,51 @@
+---
+title: A spinning ASCII asterisk, no dependencies
+date: 2026-07-06
+tags: [javascript, ascii-art, animation, graphics]
+blurb: A from-scratch 3D renderer — rotation matrices, perspective, a z-buffer, luminance shading — pointed at a six-point starburst and drawn entirely in text characters.
+read: 5 min
+featured: true
+---
+
+Claude's mark is a six-point asterisk. It seemed like a good excuse to revisit a very old trick — [Andy Sloane's spinning ASCII donut](https://www.a1k0n.net/2011/07/20/donut-math.html)[^donut] — and point the same machinery at a different shape: no torus, no canvas, no WebGL, no Three.js. Just a `<pre>` tag and a loop that rewrites its text sixty-ish times a second.
+
+<div class="ascii-asterisk" data-ascii-asterisk aria-hidden="true">
+<pre>
+                                          :...
+                                        :....
+                     ...              ::.....
+                     .....           ::.@ ...
+                     ...+...        :..@.. .
+                     ....+...      :%.@ .+..
+                      ..+..+..    :%.@..+.
+                       ..+..+..   :.@....
+                         ....... :.@...        **.** *
+                           ..... .....  ...*... .%%..%..%.. .
+                ...*.....** ............... ... .. +++..+....
+            ..........%................... ... ... ......
+         .......+++.+........:......  .............
+          ...............  ::... ......
+                          :..... ...+...
+                        ::...+.   .+.++...
+                      ::..@.. .    .+..+....
+                     ::..@.. .     ..+..++...
+                     : .  . .       ..+ .++.:.
+                    :.. ....         ...+..+..
+                    :. ....            ....++..
+                   :.@...                ......
+                   :...                    . ..
+                   ..                         .
+</pre>
+</div>
+
+The shape is a point cloud, not a bitmap: six tapered lens-shaped "spikes" built parametrically around the origin, thick at mid-shaft and pointed at both ends, arranged sixty degrees apart so they read as an asterisk face-on. Each point carries an analytic surface normal along with its position — that's what makes the shading possible.[^why-normals]
+
+Every frame, the whole cloud gets rotated with a couple of composed rotation matrices (one turn around Y, a slower wobble around X), perspective-projected down to two dimensions, and rasterized onto a fixed character grid. A z-buffer tracks the closest point claiming each cell, so the near spikes correctly occlude the far ones as it tumbles. Whatever survives gets shaded by the dot product of its normal against a fixed light direction, mapped onto a density ramp — `" .:-=+*#%@"`, sparse to dense — the same idea behind the donut's luminance-to-character mapping, just walked across a different surface.
+
+The one wrinkle worth a footnote: this page has two different rendering paths — a rich single-page view and a plain static one — and only one of them executes `<script>` tags embedded in post content.[^spa] So the renderer doesn't live inline in this post at all. It's a small global script, loaded once site-wide, that watches the page for a `<div data-ascii-asterisk>` and mounts into whatever one shows up, however it got there.
+
+It also gets out of the way when asked to: `prefers-reduced-motion` gets a single static frame instead of a loop, and with JavaScript off entirely, the frame above — baked into this very page as plain text — is all you get. No blank box, no missing demo. Just an asterisk that happens not to be spinning.
+
+[^donut]: The original — a 15-line C program that spins a torus using sines, cosines, and a fixed light source — is one of the great pieces of terminal ephemera. This is the same core idea (project, z-buffer, shade by normal), rebuilt in JS for a different mesh.
+[^why-normals]: Depth alone isn't enough to shade a rotating solid convincingly — two points at the same distance from the camera can face wildly different directions. The normal is what lets the light direction actually mean something as the shape turns.
+[^spa]: The single-page view injects article HTML via `dangerouslySetInnerHTML`; browsers never execute `<script>` elements set that way, by design. The static per-post page parses the same markup as a real document, where scripts run normally. Keeping the renderer external and DOM-driven — watch for the container, mount into it — sidesteps the discrepancy instead of fighting it.

--- a/posts/dev/2026-07-06-ascii-asterisk.md
+++ b/posts/dev/2026-07-06-ascii-asterisk.md
@@ -7,7 +7,7 @@ read: 5 min
 featured: true
 ---
 
-Claude's mark is a six-point asterisk. It seemed like a good excuse to revisit a very old trick — [Andy Sloane's spinning ASCII donut](https://www.a1k0n.net/2011/07/20/donut-math.html)[^donut] — and point the same machinery at a different shape: no torus, no canvas, no WebGL, no Three.js. Just a `<pre>` tag and a loop that rewrites its text sixty-ish times a second.
+A live 3D rendering of Claude's asterisk, drawn entirely in text characters — no canvas, no WebGL, no Three.js, just plain JavaScript rewriting a `<pre>` tag.
 
 <div class="ascii-asterisk" data-ascii-asterisk aria-hidden="true">
 <pre>
@@ -37,15 +37,3 @@ Claude's mark is a six-point asterisk. It seemed like a good excuse to revisit a
                    ..                         .
 </pre>
 </div>
-
-The shape is a point cloud, not a bitmap: six tapered lens-shaped "spikes" built parametrically around the origin, thick at mid-shaft and pointed at both ends, arranged sixty degrees apart so they read as an asterisk face-on. Each point carries an analytic surface normal along with its position — that's what makes the shading possible.[^why-normals]
-
-Every frame, the whole cloud gets rotated with a couple of composed rotation matrices (one turn around Y, a slower wobble around X), perspective-projected down to two dimensions, and rasterized onto a fixed character grid. A z-buffer tracks the closest point claiming each cell, so the near spikes correctly occlude the far ones as it tumbles. Whatever survives gets shaded by the dot product of its normal against a fixed light direction, mapped onto a density ramp — `" .:-=+*#%@"`, sparse to dense — the same idea behind the donut's luminance-to-character mapping, just walked across a different surface.
-
-The one wrinkle worth a footnote: this page has two different rendering paths — a rich single-page view and a plain static one — and only one of them executes `<script>` tags embedded in post content.[^spa] So the renderer doesn't live inline in this post at all. It's a small global script, loaded once site-wide, that watches the page for a `<div data-ascii-asterisk>` and mounts into whatever one shows up, however it got there.
-
-It also gets out of the way when asked to: `prefers-reduced-motion` gets a single static frame instead of a loop, and with JavaScript off entirely, the frame above — baked into this very page as plain text — is all you get. No blank box, no missing demo. Just an asterisk that happens not to be spinning.
-
-[^donut]: The original — a 15-line C program that spins a torus using sines, cosines, and a fixed light source — is one of the great pieces of terminal ephemera. This is the same core idea (project, z-buffer, shade by normal), rebuilt in JS for a different mesh.
-[^why-normals]: Depth alone isn't enough to shade a rotating solid convincingly — two points at the same distance from the camera can face wildly different directions. The normal is what lets the light direction actually mean something as the shape turns.
-[^spa]: The single-page view injects article HTML via `dangerouslySetInnerHTML`; browsers never execute `<script>` elements set that way, by design. The static per-post page parses the same markup as a real document, where scripts run normally. Keeping the renderer external and DOM-driven — watch for the container, mount into it — sidesteps the discrepancy instead of fighting it.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -167,6 +167,7 @@ function postPage(side, post, bodyHtml) {
   <link rel="stylesheet" href="${css}"/>
   <link rel="stylesheet" href="/shared/sidenotes.css"/>
   <link rel="stylesheet" href="/shared/previews.css"/>
+  <link rel="stylesheet" href="/shared/ascii-asterisk.css"/>
   <style>
     .post { max-width: 42rem; margin: 0 auto; padding: 56px 20px 96px; }
     .post .meta { font-family: var(--font-mono, monospace); font-size: 13px; opacity: .7; margin-bottom: 10px; }
@@ -187,6 +188,7 @@ function postPage(side, post, bodyHtml) {
   </main>
   <script src="/shared/sidenotes.js" defer></script>
   <script src="/shared/previews.js" defer></script>
+  <script src="/shared/ascii-asterisk.js" defer></script>
 </body>
 </html>
 `;

--- a/shared/ascii-asterisk.css
+++ b/shared/ascii-asterisk.css
@@ -1,0 +1,20 @@
+/* ascii-asterisk.css — container for the spinning ASCII Claude-asterisk (see ascii-asterisk.js). */
+.ascii-asterisk {
+  display: flex;
+  justify-content: center;
+  margin: 28px 0;
+  padding: 18px;
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-sunken, rgba(127, 127, 127, 0.08));
+  overflow: hidden;
+}
+.ascii-asterisk pre {
+  margin: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: clamp(6px, 1.1vw, 10px);
+  line-height: 1.05;
+  letter-spacing: 0;
+  white-space: pre;
+  color: #d97757; /* Claude coral/orange accent */
+  text-shadow: 0 0 10px rgba(217, 119, 87, 0.35);
+}

--- a/shared/ascii-asterisk.js
+++ b/shared/ascii-asterisk.js
@@ -1,0 +1,139 @@
+/* ascii-asterisk.js — a spinning 3D Claude-style asterisk, rendered as text characters only.
+
+   No canvas, no WebGL, no Three.js: six tapered "spikes" are modeled as points in 3D space
+   (with analytic surface normals), rotated every frame, perspective-projected, and rasterized
+   onto a fixed character grid with a z-buffer for occlusion — the classic "ASCII donut" shading
+   technique (luminance ramp driven by normal·light), applied to a six-point starburst instead
+   of a torus. Output is plain textContent on a <pre>, never innerHTML.
+
+   Loaded once globally (like shared/sidenotes.js) rather than as an inline <script> in the post
+   body: the SPA article view injects post HTML via dangerouslySetInnerHTML, which never executes
+   embedded <script> tags, but does create real DOM nodes for plain markup. So this script watches
+   for its container (via MutationObserver on #root, same trick as sidenotes.js) and mounts into
+   whatever <div data-ascii-asterisk> shows up, however it arrived in the DOM.
+*/
+(function () {
+  var COLS = 64, ROWS = 32;
+  var RAMP = " .:-=+*#%@";
+  var FRAME_MS = 1000 / 24;
+
+  // Six spikes at 60° increments in the XY plane, each a tapered lens (thick at mid-shaft,
+  // pointed at both the tip and the hub) so the whole thing reads as a six-point asterisk
+  // face-on, then gains real depth as it tumbles in 3D.
+  function buildPoints() {
+    var pts = [];
+    var arms = 6, uSteps = 22, vSteps = 8;
+    for (var a = 0; a < arms; a++) {
+      var theta = (a / arms) * Math.PI * 2;
+      var ca = Math.cos(theta), sa = Math.sin(theta);
+      for (var i = 0; i <= uSteps; i++) {
+        var u = i / uSteps;             // 0 (hub) .. 1 (tip), along the arm
+        var len = u * 1.0;
+        // taper profile: narrow at the hub, widest a third of the way out, pointed at the tip
+        var width = 0.16 * Math.sin(Math.pow(1 - u, 0.6) * Math.PI) * (1 - Math.pow(u, 3));
+        if (width < 0.004 && u > 0.15) continue; // let the tip actually come to a point
+        for (var j = 0; j < vSteps; j++) {
+          var phi = (j / vSteps) * Math.PI * 2;
+          var rx = Math.cos(phi) * width;
+          var rz = Math.sin(phi) * width;
+          // local frame: shaft runs along (ca, sa, 0); the tube cross-section is perpendicular
+          var x = ca * len - sa * rx;
+          var y = sa * len + ca * rx;
+          var z = rz;
+          var nx = -sa * Math.cos(phi), ny = ca * Math.cos(phi), nz = Math.sin(phi);
+          pts.push({ x: x, y: y, z: z, nx: nx, ny: ny, nz: nz });
+        }
+      }
+    }
+    return pts;
+  }
+  var BASE_POINTS = buildPoints();
+
+  function rotated(pts, ax, ay) {
+    var cosY = Math.cos(ay), sinY = Math.sin(ay);
+    var cosX = Math.cos(ax), sinX = Math.sin(ax);
+    var out = new Array(pts.length);
+    for (var i = 0; i < pts.length; i++) {
+      var p = pts[i];
+      // rotate around Y
+      var x1 = p.x * cosY + p.z * sinY, z1 = -p.x * sinY + p.z * cosY, y1 = p.y;
+      var nx1 = p.nx * cosY + p.nz * sinY, nz1 = -p.nx * sinY + p.nz * cosY, ny1 = p.ny;
+      // then around X
+      var y2 = y1 * cosX - z1 * sinX, z2 = y1 * sinX + z1 * cosX, x2 = x1;
+      var ny2 = ny1 * cosX - nz1 * sinX, nz2 = ny1 * sinX + nz1 * cosX, nx2 = nx1;
+      out[i] = { x: x2, y: y2, z: z2, nx: nx2, ny: ny2, nz: nz2 };
+    }
+    return out;
+  }
+
+  var LIGHT = normalize(-0.4, 0.5, 1);
+  function normalize(x, y, z) { var m = Math.sqrt(x * x + y * y + z * z) || 1; return { x: x / m, y: y / m, z: z / m }; }
+
+  function renderFrame(ax, ay) {
+    var pts = rotated(BASE_POINTS, ax, ay);
+    var buf = new Array(COLS * ROWS).fill(" ");
+    var zbuf = new Array(COLS * ROWS).fill(-Infinity);
+    var K = 3.4;         // camera distance
+    var scale = 46;
+    for (var i = 0; i < pts.length; i++) {
+      var p = pts[i];
+      var invz = 1 / (p.z + K);
+      var sx = Math.round(COLS / 2 + p.x * scale * invz * 2.1);
+      var sy = Math.round(ROWS / 2 - p.y * scale * invz);
+      if (sx < 0 || sx >= COLS || sy < 0 || sy >= ROWS) continue;
+      var idx = sy * COLS + sx;
+      if (invz <= zbuf[idx]) continue;
+      var lum = p.nx * LIGHT.x + p.ny * LIGHT.y + p.nz * LIGHT.z;
+      lum = Math.max(0, lum);
+      var ci = Math.min(RAMP.length - 1, Math.floor(lum * (RAMP.length - 1) * 1.15));
+      zbuf[idx] = invz;
+      buf[idx] = RAMP[ci] === " " ? RAMP[1] : RAMP[ci]; // keep visible silhouette even in shadow
+    }
+    var lines = [];
+    for (var r = 0; r < ROWS; r++) lines.push(buf.slice(r * COLS, r * COLS + COLS).join(""));
+    return lines.join("\n");
+  }
+
+  function staticFrame() {
+    return renderFrame(0.28, 0.4);
+  }
+
+  var mounted = new WeakSet();
+
+  function mount(container) {
+    if (mounted.has(container)) return;
+    mounted.add(container);
+    var pre = container.querySelector("pre");
+    if (!pre) { pre = document.createElement("pre"); container.appendChild(pre); }
+
+    var reduceMotion = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) { pre.textContent = staticFrame(); return; }
+
+    var t0 = null, raf = null, last = 0;
+    function tick(t) {
+      if (!container.isConnected) { cancelAnimationFrame(raf); mounted.delete(container); return; }
+      if (t0 === null) t0 = t;
+      if (t - last >= FRAME_MS) {
+        last = t;
+        var elapsed = (t - t0) / 1000;
+        pre.textContent = renderFrame(0.35 * Math.sin(elapsed * 0.5), elapsed * 0.6);
+      }
+      raf = requestAnimationFrame(tick);
+    }
+    raf = requestAnimationFrame(tick);
+  }
+
+  function scan() {
+    document.querySelectorAll("[data-ascii-asterisk]").forEach(mount);
+  }
+
+  var root = document.getElementById("root");
+  var observer = root ? new MutationObserver(scan) : null;
+  if (observer) observer.observe(root, { childList: true, subtree: true });
+
+  window.addEventListener("load", scan);
+  if (document.readyState !== "loading") scan();
+  else document.addEventListener("DOMContentLoaded", scan);
+
+  window.AKAsciiAsterisk = { refresh: scan };
+})();


### PR DESCRIPTION
## Summary
- New featured dev post (`posts/dev/2026-07-06-ascii-asterisk.md`) embedding a live, dependency-free 3D ASCII rendering of Claude's six-point asterisk mark — content kept to a one-line intro plus the live demo
- New `shared/ascii-asterisk.js`/`.css`: a from-scratch renderer (rotation matrices, perspective projection, z-buffer, normal-based luminance shading) that writes plain text into a `<pre>` — no canvas/WebGL/Three.js
- Wired the renderer into both render paths (`dev/index.html` and the static `postPage` template in `scripts/build.mjs`) as a global script that mounts via `MutationObserver`, since the SPA article view injects post HTML via `dangerouslySetInnerHTML` and never executes embedded `<script>` tags
- Respects `prefers-reduced-motion` (single static frame, no loop) and ships a baked-in plain-text fallback frame for the no-JS case

## Test plan
- [x] `node scripts/build-index.mjs` — new post appears in `posts.json` as `featured: true`
- [x] `NO_FETCH=1 node scripts/build.mjs` — static page builds and copies `shared/ascii-asterisk.{js,css}`
- [x] Playwright against the built static page: no console errors, `<pre>` content changes between timestamps (animation runs), screenshot confirms it reads as an asterisk
- [x] Isolated test injecting the container via `innerHTML` (standing in for the SPA's `dangerouslySetInnerHTML`) confirms an embedded `<script>` does *not* execute but the external renderer still detects and mounts the container via `MutationObserver`
- [x] `prefers-reduced-motion: reduce` via Playwright's `emulateMedia` — confirmed no loop, single static frame
