### PR TITLE
Add first blog post: Stop Consuming, Start Making

### DIFF
--- a/posts.json
+++ b/posts.json
@@ -42,6 +42,26 @@
   ],
   "personal": [
     {
+      "slug": "stop-consuming-start-making",
+      "side": "personal",
+      "title": "Stop Consuming, Start Making",
+      "date": "Jul 2026",
+      "dateLong": "Jul 13, 2026",
+      "iso": "2026-07-13",
+      "tags": [
+        "making",
+        "creativity",
+        "personal-growth",
+        "notebook"
+      ],
+      "blurb": "A lifetime of consuming without making — and the quick, ugly WarioWare microgame that finally broke the pattern.",
+      "read": "3 min",
+      "featured": true,
+      "draft": false,
+      "type": "post",
+      "path": "posts/personal/2026-07-13-stop-consuming-start-making.md"
+    },
+    {
       "slug": "a-quiet-demo",
       "side": "personal",
       "title": "A quiet demo",

--- a/posts/personal/2026-07-13-stop-consuming-start-making.md
+++ b/posts/personal/2026-07-13-stop-consuming-start-making.md
@@ -1,0 +1,29 @@
+---
+title: Stop Consuming, Start Making
+date: 2026-07-13
+tags: [making, creativity, personal-growth, notebook]
+blurb: A lifetime of consuming without making — and the quick, ugly WarioWare microgame that finally broke the pattern.
+read: 3 min
+featured: true
+---
+
+Been a while, eh?[^when]
+
+I've come to realize that I had a ton of opportunities to be creative as a kid, but never actually progressed to making things of my own. Over the years I've had access to a lot of experiences, books, tools and software. I always loved reading about how things are done but always left it at that. I've always loved playing video games, but never tried to make my own (aside from a couple I made during my bachelor's degree). I haven't even been tempted to make my own levels in games that have level creators, like Counter Strike.
+
+This realisation really hit me on watching a Scott's Stash video on YouTube where he shows off his WarioWare D.I.Y microgames that he made as a child on his Nintendo DS. I played that same game as well, went through all the tutorials and stuff, but never actually made my own. I guess I felt that I couldn't draw or make pixel art that well so why bother. The perfectionist in me even back then wanted to be good at everything, but the fear of not being so stopped me from even trying.
+
+Now looking back I feel that I "wasted" opportunities to learn and grow. I had a boxed art set but never used it seriously as I wanted to "save" the art supplies. I still have the box, and it hasn't been used. The markers have gone dry. I have a cartooning book as well which teaches how to draw cartoons, but I only read through it without actually practicing it.
+
+I think it's important to work on things you might not necessarily be good at immediately. It's important early on to not treat every project as something that has to be perfect in form and function, but to just DO it. Trying and failing and improving over time is better than not trying at all.
+
+So yesterday I forced myself to stop just consuming endless amounts of content and actually make something for once. I opened up my copy of WarioWare D.I.Y and made a microgame from scratch. It was quick and dirty, using simple objects and some preloaded assets. I came up with an idea (a laser blocking game based on the training sequence in the Millennium Falcon in the first Star Wars movie), drew some objects, placed them and edited in the A.I to make it work. I figured, make something that works first, then make the graphics look prettier later. An hour later I was done. "It's good enough for now" I thought.
+
+Today, I want to be able to catch myself when wasting time mindlessly browsing the internet and force myself to MAKE stuff. I'd like to try writing a novel, making a game for the TIC-80, making an environment in Unreal Engine 5, making a program for the Looking Glass Portrait Holographic display, make some wall-mountable but also portable and dustproof and shockproof display case(s) for my growing retro handheld collection.
+
+I also want to make a queue of all my ideas so that I always have something to work on. Ideally each item in this list will be small and concrete enough that I won't have to worry about the projects as a whole.
+
+I also have to finish up my personal website 2.0 so I can host some blog posts and tutorials for a better online portfolio. Oh and I also have to do machine learning projects and put them on my GitHub.[^fullcircle]
+
+[^when]: First notes on this were written on 23 September 2022 — posted here, lightly edited, four years later. The gap turns out to matter; see the note on the final line.
+[^fullcircle]: Written in 2022 (see the opening note). Four years on, the irony writes itself: this post is hosted on the very "personal website 2.0" I was nagging myself to finish, and those machine learning projects are up on my GitHub. The queue, it seems, eventually clears.


### PR DESCRIPTION
Publishes the first curated post to the personal side.

- Source: Obsidian journal entry (2022-09-23), lightly edited (spelling/grammar only)
- Adds margin sidenotes: original-date note + a full-circle note on the closing line
- Regenerated `posts.json` (2 personal posts now)
- Local build verified: per-post page renders, 0 unresolved annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)