### PR TITLE
Fix personal post chrome + combined Writing page

### DIFF
--- a/personal/TopNav.jsx
+++ b/personal/TopNav.jsx
@@ -1,8 +1,7 @@
 /** Top navigation bar — sticky, paper-blur. */
 function TopNav({ route, onNavigate, plain, onPlain, hasWriting, hasNotebook, hasProjects }) {
   const items = [
-    ...(hasWriting ? [{ id: "writing", label: "Writing" }] : []),
-    ...(hasNotebook ? [{ id: "notebook", label: "Notebook" }] : []),
+    ...(hasWriting || hasNotebook ? [{ id: "writing", label: "Writing" }] : []),
     ...(hasProjects ? [{ id: "projects", label: "Projects" }] : []),
     { id: "about",    label: "About"    },
   ];

--- a/personal/app.jsx
+++ b/personal/app.jsx
@@ -16,7 +16,9 @@ function App() {
     }).catch(() => {});
     const onHash = () => {
       const m = location.hash.match(/^#\/p\/(.+)$/);
-      if (m) { setSlug(decodeURIComponent(m[1])); setRoute("article"); window.scrollTo(0, 0); }
+      if (m) { setSlug(decodeURIComponent(m[1])); setRoute("article"); window.scrollTo(0, 0); return; }
+      const r = location.hash.replace(/^#\/?/, "");
+      if (r === "writing" || r === "about" || r === "projects") { setSlug(null); setRoute(r); window.scrollTo(0, 0); }
     };
     onHash();
     window.addEventListener("hashchange", onHash);
@@ -96,14 +98,14 @@ function App() {
         )}
         {route === "writing" && (
           <>
-            <div className="section-h"><h2>Writing</h2><span className="more">{writingEntries.length} piece{writingEntries.length === 1 ? "" : "s"}</span></div>
+            <div className="section-h"><h2>Essays</h2><span className="more">{writingEntries.length} piece{writingEntries.length === 1 ? "" : "s"}</span></div>
             <WritingList entries={writingEntries} onOpen={openEntry} />
-          </>
-        )}
-        {route === "notebook" && (
-          <>
-            <div className="section-h"><h2>Notebook</h2><span className="more">Short notes, in public</span></div>
-            <WritingList entries={notebookEntries} onOpen={openEntry} />
+            {notebookEntries.length > 0 && (
+              <>
+                <div className="section-h" style={{ marginTop: 64 }}><h2>Notebook</h2><span className="more">Short notes, in public</span></div>
+                <WritingList entries={notebookEntries} onOpen={openEntry} />
+              </>
+            )}
           </>
         )}
         {route === "projects" && (

--- a/personal/blocks.mjs
+++ b/personal/blocks.mjs
@@ -21,11 +21,13 @@ export function personalBlocks({ route, entries = [], current, currentMd, rp = {
     ];
   }
   if (route === "writing" || route === "notebook") {
-    const list = route === "notebook" ? entries.filter(isNotebook) : entries.filter(e => !isNotebook(e));
-    return [
-      { t: "h1", text: `arslan.land — ${route}` },
-      { t: "table", head: ["piece", "date", "tag"], rows: list.map(e => [{ text: e.title, href: `#/p/${e.slug}` }, e.date, e.tag || ""]) },
-    ];
+    const essays = entries.filter(e => !isNotebook(e));
+    const notes = entries.filter(isNotebook);
+    const rowsOf = (list) => list.map(e => [{ text: e.title, href: `#/p/${e.slug}` }, e.date, e.tag || ""]);
+    const b = [{ t: "h1", text: "arslan.land — writing" }];
+    if (essays.length) b.push({ t: "h2", text: "Essays" }, { t: "table", head: ["piece", "date", "tag"], rows: rowsOf(essays) });
+    if (notes.length) b.push({ t: "h2", text: "Notebook" }, { t: "table", head: ["piece", "date", "tag"], rows: rowsOf(notes) });
+    return b;
   }
   const books = rp.books || [], games = rp.games || {}, now = games.now || {};
   const b = [

--- a/posts.json
+++ b/posts.json
@@ -51,8 +51,7 @@
       "tags": [
         "making",
         "creativity",
-        "personal-growth",
-        "notebook"
+        "personal-growth"
       ],
       "blurb": "A lifetime of consuming without making — and the quick, ugly WarioWare microgame that finally broke the pattern.",
       "read": "3 min",

--- a/posts/personal/2026-07-13-stop-consuming-start-making.md
+++ b/posts/personal/2026-07-13-stop-consuming-start-making.md
@@ -1,7 +1,7 @@
 ---
 title: Stop Consuming, Start Making
 date: 2026-07-13
-tags: [making, creativity, personal-growth, notebook]
+tags: [making, creativity, personal-growth]
 blurb: A lifetime of consuming without making — and the quick, ugly WarioWare microgame that finally broke the pattern.
 read: 3 min
 featured: true

--- a/posts/personal/2026-07-15-theoretical-shopping.md
+++ b/posts/personal/2026-07-15-theoretical-shopping.md
@@ -1,7 +1,7 @@
 ---
 title: Theoretical Shopping
 date: 2026-07-15
-tags: [gear, philosophy, notebook]
+tags: [gear, philosophy]
 blurb: A habit I call theoretical shopping — doing the research to choose the best product for a purpose, without necessarily buying it.
 read: 3 min
 featured: false

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -156,6 +156,8 @@ function postPage(side, post, bodyHtml) {
     ? "https://arslankazmi.github.io/ak-design/dist/dev.css"
     : "https://arslankazmi.github.io/ak-design/dist/personal.css";
   const site = side === "dev" ? "arslan.dev" : "arslan.land";
+  const other = side === "dev" ? { href: "../../../personal/", label: "arslan.land" } : { href: "../../../dev/", label: "arslan.dev" };
+  const navBg = side === "dev" ? "var(--bg, #0b0d10)" : "var(--paper, #edece4)";
   const meta = he([post.dateLong || post.date, (post.tags || []).join(", ")].filter(Boolean).join(" · "));
   const enhCss = ENHANCEMENTS.filter(n => existsSync(join(REPO, "shared", `${n}.css`)))
     .map(n => `  <link rel="stylesheet" href="/shared/${n}.css"/>`).join("\n");
@@ -179,15 +181,31 @@ ${enhCss}
     .post .prose pre { overflow:auto; padding:14px; border-radius:8px; background:rgba(127,127,127,.12); }
     .post img { max-width: 100%; height: auto; }
     .post .back { font-family: var(--font-mono, monospace); font-size: 13px; display:inline-block; margin-top:40px; }
+    .post-nav { position: sticky; top: 0; z-index: 50; display:flex; align-items:center; justify-content:space-between; gap:16px; padding:14px 24px; border-bottom:1px solid var(--border, rgba(127,127,127,.25)); background:${navBg}; backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px); }
+    .post-nav .brand { font-family: var(--font-display, Georgia, serif); font-weight:700; font-size:18px; color:var(--fg1, inherit); text-decoration:none; }
+    .post-nav .links { display:flex; gap:18px; align-items:center; }
+    .post-nav .links a { font-family: var(--font-body, sans-serif); font-size:14px; color:var(--fg1, inherit); text-decoration:none; }
+    .post-nav .links a:hover { color: var(--accent, #2563eb); }
+    .post-footer { border-top:1px solid var(--border, rgba(127,127,127,.25)); margin-top:64px; padding:28px 24px 40px; font-family: var(--font-mono, monospace); font-size:12px; color:var(--fg2, #666); text-align:center; }
+    .post-footer a { color: inherit; }
   </style>
 </head>
 <body>
+  <header class="post-nav">
+    <a class="brand" href="../../">${site}</a>
+    <nav class="links">
+      <a href="../../#/writing">Writing</a>
+      <a href="../../#/about">About</a>
+      <a href="${other.href}">${other.label} ↗</a>
+    </nav>
+  </header>
   <main class="post">
     <div class="meta">${meta}</div>
     <h1>${he(post.title)}</h1>
     <div class="prose">${bodyHtml}</div>
-    <a class="back" href="../../">← all writing</a>
+    <a class="back" href="../../#/writing">← all writing</a>
   </main>
+  <footer class="post-footer">Written by hand · <a href="/acknowledgements/">acknowledgements</a> · © ${new Date().getFullYear()} Arslan Kazmi</footer>
 ${enhJs}
 </body>
 </html>

--- a/shared/sidenotes.js
+++ b/shared/sidenotes.js
@@ -30,6 +30,7 @@
     var section = prose.querySelector("section[data-footnotes]");
     prose.querySelectorAll("aside.sidenote").forEach(function (n) { n.remove(); });
     prose.classList.remove("has-sidenotes");
+    prose.style.minHeight = "";
     if (!section) return;
 
     var rect = prose.getBoundingClientRect();
@@ -57,6 +58,10 @@
       bottom[side] = top + aside.offsetHeight;
       i++;
     });
+    // Absolutely-positioned sidenotes don't stretch .prose; reserve space for the lowest note so a
+    // tall note near the end of the article can't spill over the footer / following content.
+    var maxBottom = Math.max(bottom.left, bottom.right);
+    if (maxBottom > prose.offsetHeight) prose.style.minHeight = (maxBottom + 8) + "px";
   }
 
   function relayout() {


### PR DESCRIPTION
Fixes the issues on the personal side after publishing the first post.

**Bugs**
1. **Sidenotes spilling over the footer** — margin notes are `position:absolute` in `.prose`, which doesn't stretch the parent; a tall note near the article's end overflowed. Now `sidenotes.js` reserves bottom space (min-height) equal to the lowest note.
2. **No site header on opened posts** — the standalone `/personal/p/slug/` page (`postPage()`) had no chrome. Added a sticky header + footer; back-link now goes to the Writing list.

**Content model**
3. **Writing page** now shows **Essays + Notebook as two sections on one page** (removed the separate Notebook route/nav). Added hash routes (`#/writing`, `#/about`) so post-page nav can deep-link.
4. **notebook tag** removed from essays (Stop Consuming, Theoretical Shopping) so they surface under 'Read the latest'.

Verified locally in-browser at 1440px: header/footer present, sidenote contained above the footer, Writing page shows both sections, Stop Consuming now under Essays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)