### PR TITLE
CLAUDE.md + dropcap rule + fix Stop Consuming dropcap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md — working notes for arslankazmi.github.io
+
+Conventions for editing this repo, plus the live content calendars. This file is **not** shipped to
+the site (`scripts/build.mjs` copies only `assets, shared, dev, personal, posts, acknowledgements`
+into `_public/`). The repo is public, so treat everything here as visible on GitHub.
+
+---
+
+## What this is
+
+One repo, **two sides**: `/dev` (arslan.dev — dark, monospace developer hub) and `/personal`
+(arslan.land — warm paper, essays & notebook). Root `/` is a coin-flip splash. Each side is a React
+SPA (React UMD + Babel-standalone via CDN) with a **gwern-style static build** that also renders a
+no-JS baseline and a standalone HTML page per post.
+
+## Build & publish
+
+- `npm run index` — regenerate `posts.json` (the post index).
+- `npm run build` — full build into `_public/` (also regenerates `posts.json`). `_public/` is gitignored.
+- `npm run build:drafts` — include `draft: true` posts (local preview only).
+- `npm run serve` — serve `_public/` at localhost:8080.
+- **Deploy**: push to `main` → `.github/workflows/deploy.yml` runs `npm run build` and deploys to
+  GitHub Pages. Publish a post via a branch → PR → merge to `main`.
+- Repo-local git email is `akazmi.public@gmail.com` (don't touch global config).
+
+## Authoring a post
+
+- File: `posts/{dev,personal}/YYYY-MM-DD-slug.md`.
+- Frontmatter: `title, date, tags, blurb, read, featured` (+ `draft: true` to keep it out of the build).
+- Footnotes (`[^x]`) render as **margin sidenotes** on wide screens (`shared/sidenotes.js`),
+  degrading to bottom footnotes when narrow or JS-off.
+
+## Essay vs. notebook (personal side)
+
+A personal post is a **notebook** entry if any tag is `notebook` or `music`
+(`isNotebook` in `personal/blocks.mjs` + `personal/app.jsx`); otherwise it's an **essay**. Essays
+appear under "Latest writing" / "Read the latest"; notebook entries show in the **Notebook** section
+of the one Writing page. So: tag short notes `notebook`; leave essays untagged as such.
+
+## Dropcap rule (personal side)
+
+Every **personal** post (essay **and** notebook) must **open with a letter that has an approved
+Goudy Initialen dropcap glyph: `C, E, I, P, S, T, U, W`** (`assets/dropcaps/GoudyInitialen-*.ttf`).
+These render as the ornamental dropcap; any other first letter falls back to the accent font, which
+is **not** allowed. If a piece would open with another letter, **reword the first line** to start
+with an approved letter (preferred), or add the matching `GoudyInitialen-<L>.ttf` to
+`assets/dropcaps/` and wire it into `personal/styles.css` (and the static-page block in
+`scripts/build.mjs postPage()`). The dropcap shows in both the SPA article view and the static page.
+
+## Editorial policy
+
+- **Light touch** — the author's exact words; fix spelling/grammar only; strip Obsidian syntax
+  (`[[wikilinks]]`, `![[embeds]]`, ` ```toc `, `-->[…]<--`). Don't rewrite; flag any connective glue.
+- **Privacy lens** — general philosophies / transferable ideas over detailed personal preferences
+  (no gear rankings, favourites lists).
+- **Provenance** — journal-derived posts carry a `[^when]` sidenote worded
+  "First notes on this were written on <date>." and publish under a fresh date.
+
+---
+
+# Content calendar — dev (arslan.dev)
+
+Readiness: **High** = light-fix · **Med** = needs finishing. Effort: 🟢 copyedit · 🟡 finish/tighten · 🔴 write/stitch.
+
+| # | Date | Title | Ready | Effort | Note |
+|---|---|---|---|---|---|
+| 1 | Jul 14 | Semantic Scholar — a Google Scholar alternative | Med | 🟢 | Quick tool tip. |
+| 2 | Jul 22 | A Structured Approach to Taking Notes on Scientific Papers | High | 🟢 | ✅ Drafted (`draft:true`). |
+| 3 | Jul 25 | **AI & Craft (1):** AI Dependence and the Deskilling of Developers | High | 🟢 | ✅ Drafted. Flagship. |
+| 4 | Aug 1 | **AI & Craft (2):** Losing the Hands-On Feeling | High | 🟢 | ✅ Drafted. |
+| 5 | Aug 8 | **AI & Craft (3):** Three Modes I Want to Use AI In | High | 🟢 | ✅ Drafted. Manifesto. |
+| 6 | Aug 15 | Four Levels of Using an LLM *(→2026)* | High | ✍️ | First pass assembled; with author to personalize. |
+| 7 | Aug 22 | The rise of NLP in my lifetime | High | 🟡 | First-hand field memoir (02-19). |
+| 8 | Aug 29 | Skilled people quietly use Claude to ship | High | 🟡 | Timely; names this blog (07-10). |
+
+**AI & Craft arc** = #3 → #4 → #5 (deskilling → the felt cost → the way forward), capstoned by **#6 Four Levels**.
+
+**Backlog (dev):**
+- *DL/ML technical:* Attention explained (Q/K/V) · Building a bigram → transformer from scratch · GPUs: buy vs cloud · Structuring ML repos for production · Tracing/versioning prompts with Langfuse · Reacting to Anthropic's multi-agent essay.
+- *Needs finishing:* Is it bad that AI writes all my tests? · From software engineer to AI skeptic · My evolving use of AI in development.
+- *MemPalace (2026):* What to remember, and for whom · Document knowledge-graph over RAG · Keyless-safe LLM apps · Lean ML dependencies.
+- *Misc:* Finetuning on a 1660 Ti · Designing the Ideal Blog (sidenotes).
+
+**Four Levels outline (#6):** L1 raw API · L2 chaining · L3 tools/functions-as-tools · L4 agentic · *Interlude* finetuning on a 1660 Ti · *Level Four revisited (2026, written fresh)* eval-not-vibes · provider factory · free/local RAG · feedback loops · *Close.*
+
+---
+
+# Content calendar — personal (arslan.land)
+
+**Type:** *essay* (default; under "Latest writing") · *notebook* (tagged `notebook`; Notebook section).
+Remember the **dropcap rule** — each must open with `C/E/I/P/S/T/U/W`.
+
+| # | Date | Title | Type | Ready | Effort | Note |
+|---|---|---|---|---|---|---|
+| 1 | Jul 13 | Stop Consuming, Start Making | essay | High | ✅ | **PUBLISHED & LIVE**. |
+| 2 | Jul 15 | Theoretical Shopping | essay | High | 🟢 | ✅ Drafted (`draft:true`). |
+| 3 | Jul 29 | What Typing Taught Me | essay | High | 🟢 | Skill-acquisition philosophy. |
+| 4 | Aug 5 | My history with Nintendo Handhelds | essay | High | 🟡 | Trim excess model detail. |
+| 5 | Aug 12 | Addicted to Learning | notebook | High | 🟡 | ✅ Drafted — **opens "For…" (F); reword to an approved dropcap letter before publish.** |
+| 6 | Aug 19 | VTIN Speaker: a repair saga | essay | High | 🟢 | Three-act narrative. |
+| 7 | Aug 26 | The Seinfeld Machete Order | notebook | High | 🟢 | ✅ Drafted. |
+| 8 | Sep 2 | Looking Back to Move Forward | essay | High | 🟡 | Memoir; trim personal detail. |
+
+**Backlog (personal):**
+- *Pulled from the launch burst:* Dining Table Lazy Susan · The Aiming Zone (CS2 flow state).
+- *Quiet essays (local vault):* In defense of talking about the weather · Even introverts don't want to be truly alone · Following breadcrumbs: how memory retrieves.
+- *Other:* Gunpei Yokoi & Withered Technology · The Last Trucker (short fiction, optional prose thread).

--- a/posts/personal/2026-07-13-stop-consuming-start-making.md
+++ b/posts/personal/2026-07-13-stop-consuming-start-making.md
@@ -7,9 +7,7 @@ read: 3 min
 featured: true
 ---
 
-Been a while, eh?[^when]
-
-I've come to realize that I had a ton of opportunities to be creative as a kid, but never actually progressed to making things of my own. Over the years I've had access to a lot of experiences, books, tools and software. I always loved reading about how things are done but always left it at that. I've always loved playing video games, but never tried to make my own (aside from a couple I made during my bachelor's degree). I haven't even been tempted to make my own levels in games that have level creators, like Counter Strike.
+I've come to realize that I had a ton of opportunities to be creative as a kid, but never actually progressed to making things of my own.[^when] Over the years I've had access to a lot of experiences, books, tools and software. I always loved reading about how things are done but always left it at that. I've always loved playing video games, but never tried to make my own (aside from a couple I made during my bachelor's degree). I haven't even been tempted to make my own levels in games that have level creators, like Counter Strike.
 
 This realisation really hit me on watching a Scott's Stash video on YouTube where he shows off his WarioWare D.I.Y microgames that he made as a child on his Nintendo DS. I played that same game as well, went through all the tutorials and stuff, but never actually made my own. I guess I felt that I couldn't draw or make pixel art that well so why bother. The perfectionist in me even back then wanted to be good at everything, but the fear of not being so stopped me from even trying.
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -158,6 +158,16 @@ function postPage(side, post, bodyHtml) {
   const site = side === "dev" ? "arslan.dev" : "arslan.land";
   const other = side === "dev" ? { href: "../../../personal/", label: "arslan.land" } : { href: "../../../dev/", label: "arslan.dev" };
   const navBg = side === "dev" ? "var(--bg, #0b0d10)" : "var(--paper, #edece4)";
+  // Ornamental dropcap (personal side): only for letters with an approved Goudy Initialen glyph,
+  // never the accent-font fallback. Mirrors personal/styles.css.
+  const APPROVED_DROPCAPS = "CEIPSTUW";
+  const firstLetter = (bodyHtml.replace(/<[^>]+>/g, "").trim().match(/[A-Za-z]/) || [""])[0].toUpperCase();
+  const dropcap = (side === "personal" && APPROVED_DROPCAPS.includes(firstLetter)) ? firstLetter : "";
+  const dropcapCss = !dropcap ? "" : [...APPROVED_DROPCAPS].map(L =>
+    `    @font-face { font-family: 'dropcap-${L}'; src: url('../../../assets/dropcaps/GoudyInitialen-${L}.ttf') format('truetype'); font-display: swap; }`).join("\n")
+    + `\n    .post .prose[data-dropcap] > p:first-of-type::first-letter { font-family: var(--font-accent), 'Fraunces', serif; font-size: 5.2em; line-height: 0.72; font-weight: 400; float: left; margin: 0.08em 0.08em -0.05em 0; color: var(--accent); }\n`
+    + [...APPROVED_DROPCAPS].map(L =>
+    `    .post .prose[data-dropcap="${L}"] > p:first-of-type::first-letter { font-family: 'dropcap-${L}', var(--font-accent), serif; }`).join("\n");
   const meta = he([post.dateLong || post.date, (post.tags || []).join(", ")].filter(Boolean).join(" · "));
   const enhCss = ENHANCEMENTS.filter(n => existsSync(join(REPO, "shared", `${n}.css`)))
     .map(n => `  <link rel="stylesheet" href="/shared/${n}.css"/>`).join("\n");
@@ -188,6 +198,7 @@ ${enhCss}
     .post-nav .links a:hover { color: var(--accent, #2563eb); }
     .post-footer { border-top:1px solid var(--border, rgba(127,127,127,.25)); margin-top:64px; padding:28px 24px 40px; font-family: var(--font-mono, monospace); font-size:12px; color:var(--fg2, #666); text-align:center; }
     .post-footer a { color: inherit; }
+${dropcapCss}
   </style>
 </head>
 <body>
@@ -202,7 +213,7 @@ ${enhCss}
   <main class="post">
     <div class="meta">${meta}</div>
     <h1>${he(post.title)}</h1>
-    <div class="prose">${bodyHtml}</div>
+    <div class="prose"${dropcap ? ` data-dropcap="${dropcap}"` : ""}>${bodyHtml}</div>
     <a class="back" href="../../#/writing">← all writing</a>
   </main>
   <footer class="post-footer">Written by hand · <a href="/acknowledgements/">acknowledgements</a> · © ${new Date().getFullYear()} Arslan Kazmi</footer>


### PR DESCRIPTION
Adds a root `CLAUDE.md` (conventions + both content calendars + a dropcap rule) and fixes the dropcap on the published Stop Consuming post.

- **CLAUDE.md** — not shipped to the site (`build.mjs` copy list excludes it); repo is public.
- **Dropcap rule** — personal posts must open with an approved Goudy Initialen letter (C/E/I/P/S/T/U/W); other letters fall back to the accent font, which isn't allowed.
- **build.mjs** — the ornamental dropcap now also renders on the standalone static post page (was SPA-only).
- **Stop Consuming** — opened with 'Been a while, eh?' → 'B' (no glyph). Removed the greeting so it opens on 'I've come to realize…' → 'I'; moved `[^when]`.

Verified locally in-browser: the static page shows the Goudy 'I' dropcap; CLAUDE.md is absent from `_public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)