### PR TITLE
Dev: rename Writing→Posts + revalidate posts.json

### DIFF
--- a/dev/Nav.jsx
+++ b/dev/Nav.jsx
@@ -9,7 +9,7 @@ function DHNav({ route, onNavigate, plain, onPlain, hasWriting }) {
       </div>
       <div className="links">
         <a className={route === "home" ? "active" : ""} onClick={() => onNavigate("home")}>Home</a>
-        {hasWriting && <a className={route === "writing" || route === "article" ? "active" : ""} onClick={() => onNavigate("writing")}>Writing</a>}
+        {hasWriting && <a className={route === "writing" || route === "article" ? "active" : ""} onClick={() => onNavigate("writing")}>Posts</a>}
         <a href="../portfolio/">Projects ↗</a>
       </div>
       <div className="right">

--- a/dev/Writing.jsx
+++ b/dev/Writing.jsx
@@ -50,7 +50,7 @@ function Article({ post, onBack }) {
       {html == null
         ? <p className="dh-empty">Loading…</p>
         : <div className="prose" dangerouslySetInnerHTML={{ __html: html }} />}
-      <p style={{ marginTop: 40 }}><a className="dh-back" onClick={onBack}>← all writing</a></p>
+      <p style={{ marginTop: 40 }}><a className="dh-back" onClick={onBack}>← all posts</a></p>
     </article>
   );
 }

--- a/dev/app.jsx
+++ b/dev/app.jsx
@@ -19,7 +19,7 @@ const PROJECTS_URL = "https://arslankazmi.github.io/portfolio/data/projects.json
 function HomeLayouts({ posts, repos, stats, onMore }) {
   const writing = posts.length > 0 && (
     <>
-      <div className="dh-sec"><h2>Latest writing</h2><span className="hint"><a onClick={onMore}>all posts →</a></span></div>
+      <div className="dh-sec"><h2>Latest posts</h2><span className="hint"><a onClick={onMore}>all posts →</a></span></div>
       <PostList posts={posts.slice(0, 3)} onOpen={(p) => { location.hash = `#/p/${p.slug}`; }} />
     </>
   );
@@ -51,7 +51,7 @@ function App() {
   const [plain, setPlain] = useState(document.documentElement.getAttribute("data-view") === "plain");
 
   useEffect(() => {
-    fetch("../posts.json").then(r => r.json()).then(d => setPosts(d.dev || [])).catch(() => {});
+    fetch("../posts.json", { cache: "no-cache" }).then(r => r.json()).then(d => setPosts(d.dev || [])).catch(() => {});
     fetch(PROJECTS_URL).then(r => r.json()).then(d => setRepos((d.projects || []).map(p => ({
       name: p.name, desc: p.description || "", tags: (p.keywords || []).slice(0, 3),
       lang: p.language || "", langVar: LANG_VAR[p.language] || "--lang-other",
@@ -80,7 +80,8 @@ function App() {
 
     const onHash = () => {
       const m = location.hash.match(/^#\/p\/(.+)$/);
-      if (m) { setSlug(decodeURIComponent(m[1])); setRoute("article"); window.scrollTo(0, 0); }
+      if (m) { setSlug(decodeURIComponent(m[1])); setRoute("article"); window.scrollTo(0, 0); return; }
+      if (location.hash.replace(/^#\/?/, "") === "writing") { setSlug(null); setRoute("writing"); window.scrollTo(0, 0); }
     };
     onHash();
     window.addEventListener("hashchange", onHash);
@@ -116,7 +117,7 @@ function App() {
       <div className="plain-root">
         <p className="pm-nav">
           <a onClick={togglePlain}>← rich view</a> · <a onClick={() => navigate("home")}>home</a>
-          {posts.length ? <> · <a onClick={() => navigate("writing")}>writing</a></> : null}
+          {posts.length ? <> · <a onClick={() => navigate("writing")}>posts</a></> : null}
           {" "}· <a href="../portfolio/">projects</a> · <a href="../personal/">arslan.land</a>
         </p>
         <PlainBlocks blocks={buildBlocks()} />
@@ -132,7 +133,7 @@ function App() {
         {route === "home" && <HomeLayouts posts={posts} repos={repos} stats={stats} onMore={() => navigate("writing")} />}
         {route === "writing" && (
           <>
-            <div className="dh-sec"><h2>Writing</h2><span className="hint">{posts.length} post{posts.length === 1 ? "" : "s"}</span></div>
+            <div className="dh-sec"><h2>Posts</h2><span className="hint">{posts.length} post{posts.length === 1 ? "" : "s"}</span></div>
             <PostList posts={posts} onOpen={openPost} />
           </>
         )}

--- a/dev/blocks.mjs
+++ b/dev/blocks.mjs
@@ -11,7 +11,7 @@ export function devBlocks({ route, posts = [], repos = [], stats = [], current, 
   }
   if (route === "writing") {
     return [
-      { t: "h1", text: "arslan.dev — writing" },
+      { t: "h1", text: "arslan.dev — posts" },
       { t: "table", head: ["post", "date", "tags"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date, (p.tags || []).join(", ")]) },
     ];
   }
@@ -21,7 +21,7 @@ export function devBlocks({ route, posts = [], repos = [], stats = [], current, 
     { t: "h1", text: "arslan.dev" },
     { t: "p", text: dh.tagline || "" },
   ];
-  if (posts.length) b.push({ t: "h2", text: "Writing" }, { t: "table", head: ["post", "date"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date]) });
+  if (posts.length) b.push({ t: "h2", text: "Posts" }, { t: "table", head: ["post", "date"], rows: posts.map(p => [{ text: p.title, href: `#/p/${p.slug}` }, p.date]) });
   b.push(
     { t: "h2", text: "Projects" },
     // 3-up grid of repo tiles, like the rich grid.

--- a/personal/app.jsx
+++ b/personal/app.jsx
@@ -11,7 +11,7 @@ function App() {
   const [plain, setPlain] = useState(document.documentElement.getAttribute("data-view") === "plain");
 
   useEffect(() => {
-    fetch("../posts.json").then(r => r.json()).then(d => {
+    fetch("../posts.json", { cache: "no-cache" }).then(r => r.json()).then(d => {
       setEntries((d.personal || []).map(p => ({ ...p, id: p.slug, tag: (p.tags || [])[0] || "" })));
     }).catch(() => {});
     const onHash = () => {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -158,6 +158,8 @@ function postPage(side, post, bodyHtml) {
   const site = side === "dev" ? "arslan.dev" : "arslan.land";
   const other = side === "dev" ? { href: "../../../personal/", label: "arslan.land" } : { href: "../../../dev/", label: "arslan.dev" };
   const navBg = side === "dev" ? "var(--bg, #0b0d10)" : "var(--paper, #edece4)";
+  const writingLabel = side === "dev" ? "Posts" : "Writing";           // dev side calls them "Posts"
+  const navSecondary = side === "dev" ? "" : `\n      <a href="../../#/about">About</a>`;  // dev has no About route
   // Ornamental dropcap (personal side): wrap the first letter in a <span> — NOT ::first-letter, which
   // in Chrome double-paints the fallback glyph + the web-font glyph when the font arrives via
   // font-display:swap after first paint. The full Goudy Initialen face covers every capital A–Z.
@@ -206,8 +208,7 @@ ${dropcapCss}
   <header class="post-nav">
     <a class="brand" href="../../">${site}</a>
     <nav class="links">
-      <a href="../../#/writing">Writing</a>
-      <a href="../../#/about">About</a>
+      <a href="../../#/writing">${writingLabel}</a>${navSecondary}
       <a href="${other.href}">${other.label} ↗</a>
     </nav>
   </header>
@@ -215,7 +216,7 @@ ${dropcapCss}
     <div class="meta">${meta}</div>
     <h1>${he(post.title)}</h1>
     <div class="prose">${bodyOut}</div>
-    <a class="back" href="../../#/writing">← all writing</a>
+    <a class="back" href="../../#/writing">← all ${writingLabel.toLowerCase()}</a>
   </main>
   <footer class="post-footer">Written by hand · <a href="/acknowledgements/">acknowledgements</a> · © ${new Date().getFullYear()} Arslan Kazmi</footer>
 ${enhJs}


### PR DESCRIPTION
Two dev-side fixes:

1. **New posts not showing** — root cause was a **stale cached `posts.json`** (the data + code were correct; a fresh load showed the post). Now both sides fetch `posts.json` with `{ cache: 'no-cache' }` so a newly published post appears immediately, without waiting for the browser cache to expire.
2. **Rename Writing → Posts on the dev side** — nav item, 'Latest posts' section, route heading, back-links, plain/no-JS labels, and the static post-page header (side-aware: dev = 'Posts', personal keeps 'Writing'). Dev SPA now also routes `#/writing` so the static-page 'Posts' link works.

Verified in-browser: dev hub reads Home · Posts · Projects, 'Latest posts' lists the Deskilling essay first; personal side unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)