### PR TITLE
Add figure/caption styling + image & cartoon conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,38 @@ opening letter gets one automatically — no restriction, nothing to do. The dro
 the SPA article view (`personal/styles.css`) and the standalone static page
 (`scripts/build.mjs postPage()`).
 
+## Images & cartoons
+
+**Every new post ships with at least one xkcd-style stick-figure cartoon, drawn or ideated by the
+author.** This is a hard rule — *do not publish a post without one*. At publish time, remind the
+author to draw/add the cartoon before the merge, and offer to ideate: pitch the gag + a
+panel-by-panel breakdown (and optionally a rough SVG storyboard) so they never start from a blank
+page. The author photographs/scans the final drawing and it becomes the post's figure.
+
+**Paths (the one gotcha):** always reference images with a **root-absolute path** —
+`/assets/img/<slug>/name.ext`. Never relative (`../`): static post pages sit 3 dirs deep
+(`/personal/p/<slug>/`) while the hash-routed SPA resolves 1 dir deep (`/personal/`), so only
+`/assets/...` resolves in both. Drop files under `assets/img/<slug>/` (the whole `assets/` tree ships
+to `_public/` automatically). Inline `<svg>` diagrams may be embedded directly in the markdown — they
+render in both contexts too.
+
+**Figure markup** (marked passes raw HTML through; `.prose figure` / `figcaption` are styled in
+`shared/sidenotes.css` + the inline block in `build.mjs postPage()`):
+
+```html
+<figure>
+  <img src="/assets/img/<slug>/panel.png" alt="describe the cartoon">
+  <figcaption>Optional caption. <cite>Credit</cite></figcaption>
+</figure>
+```
+
+Or plain `![alt](/assets/img/<slug>/name.png)` when no caption is needed. Images get gwern-style
+hover-zoom for free.
+
+**Attribution:** the author's own cartoons/drawings need **no** credit line — they're original work.
+Any *sourced* image (public-domain vintage art, openly-licensed photos) must get a `<cite>` credit in
+the caption **and** a line in `ASSET_CREDITS.md` + the acknowledgements page (`acknowledgements/index.html`).
+
 ## Editorial policy
 
 - **Light touch** — the author's exact words; fix spelling/grammar only; strip Obsidian syntax

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -193,6 +193,10 @@ ${enhCss}
     .post .prose h2, .post .prose h3 { font-family: var(--font-display, Georgia, serif); margin-top: 1.6em; }
     .post .prose pre { overflow:auto; padding:14px; border-radius:8px; background:rgba(127,127,127,.12); }
     .post img { max-width: 100%; height: auto; }
+    .post .prose figure { margin: 1.8rem 0; text-align: center; }
+    .post .prose figure img { display: block; margin: 0 auto; }
+    .post .prose figure figcaption { margin-top: 0.6rem; font-family: var(--font-body, inherit); font-size: 0.85rem; line-height: 1.45; color: var(--fg2, #666); }
+    .post .prose figure figcaption cite { font-style: italic; }
     .post .back { font-family: var(--font-mono, monospace); font-size: 13px; display:inline-block; margin-top:40px; }
     .post-nav { position: sticky; top: 0; z-index: 50; display:flex; align-items:center; justify-content:space-between; gap:16px; padding:14px 24px; border-bottom:1px solid var(--border, rgba(127,127,127,.25)); background:${navBg}; backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px); }
     .post-nav .brand { font-family: var(--font-display, Georgia, serif); font-weight:700; font-size:18px; color:var(--fg1, inherit); text-decoration:none; }

--- a/shared/sidenotes.css
+++ b/shared/sidenotes.css
@@ -9,6 +9,19 @@
    SPA article contexts all use .prose, and this file is loaded in all of them). */
 .prose img { max-width: 100%; height: auto; }
 
+/* Figures — centered image with a caption below (loaded in every .prose context). The caption is
+   also where a visible credit line goes: wrap it in <cite> for the muted, italicised source. */
+.prose figure { margin: 1.8rem 0; text-align: center; }
+.prose figure img { display: block; margin: 0 auto; }
+.prose figure figcaption {
+  margin-top: 0.6rem;
+  font-family: var(--font-body, inherit);
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--fg2, #666);
+}
+.prose figure figcaption cite { font-style: italic; }
+
 /* Footnote reference markers (marked-footnote: <sup><a data-footnote-ref>). */
 .prose a[data-footnote-ref] {
   text-decoration: none;


### PR DESCRIPTION
## What

Sets up low-friction images for the blog.

- **Figure/caption styling** — `.prose figure` / `figcaption` in `shared/sidenotes.css` (SPA + static) and the inlined `postPage()` block in `build.mjs`. Bare images already worked; now captioned figures look right and there's a home for a `<cite>` credit line.
- **Conventions in `CLAUDE.md`** —
  - Root-absolute image paths (`/assets/img/<slug>/name.ext`) — the only format that resolves in *both* the 3-dir-deep static page and the 1-dir-deep hash-routed SPA.
  - `<figure>` markup snippet.
  - **Cartoon-per-post rule**: every new post ships with ≥1 author-drawn xkcd-style stick-figure cartoon; publish-time reminder + ideation support.
  - Attribution policy (author cartoons need none; sourced art needs `<cite>` + `ASSET_CREDITS.md` + acknowledgements).

## Verify

Built with a throwaway `<figure>` draft: the figure block + caption + `<cite>` pass through `marked` into the static page, inline CSS is present, and figure rules ship in `_public/shared/sidenotes.css` (covers the SPA). Test post removed.

No behavior change for existing posts — purely additive styling + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)