### PR TITLE
feat: Fun section + native HTML5 Tritris

### DIFF
--- a/fun/assets/tritris.svg
+++ b/fun/assets/tritris.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 220" role="img" aria-label="Tritris">
+  <defs>
+    <!-- hand-drawn wobble: turbulence + displacement gives every edge a sketchy waver -->
+    <filter id="rough" x="-10%" y="-10%" width="120%" height="120%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="2" seed="5" result="n"/>
+      <feDisplacementMap in="SourceGraphic" in2="n" scale="2.6" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+    <filter id="roughSoft" x="-10%" y="-10%" width="120%" height="120%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="2" seed="9" result="n"/>
+      <feDisplacementMap in="SourceGraphic" in2="n" scale="1.8"/>
+    </filter>
+  </defs>
+
+  <!-- dark playfield background (matches the game) -->
+  <rect x="-40" y="-40" width="400" height="300" fill="#101218"/>
+  <!-- hand-drawn frame -->
+  <rect x="10" y="10" width="300" height="200" rx="14" fill="none" stroke="#ffffff" stroke-width="1.6"
+        stroke-opacity="0.16" stroke-dasharray="1 0" filter="url(#roughSoft)"/>
+
+  <g filter="url(#rough)" stroke-linejoin="round">
+    <!-- T tetromino, scattered top-left -->
+    <g transform="translate(24 24) rotate(-13)">
+      <g stroke="#241f1a" stroke-width="2.4">
+        <rect x="18" y="0"  width="18" height="18" rx="3" fill="#a860d6"/>
+        <rect x="0"  y="18" width="18" height="18" rx="3" fill="#a860d6"/>
+        <rect x="18" y="18" width="18" height="18" rx="3" fill="#a860d6"/>
+        <rect x="36" y="18" width="18" height="18" rx="3" fill="#a860d6"/>
+      </g>
+      <g fill="#ffffff" fill-opacity="0.32">
+        <rect x="20" y="2"  width="14" height="6" rx="2"/>
+        <rect x="2"  y="20" width="14" height="6" rx="2"/>
+        <rect x="20" y="20" width="14" height="6" rx="2"/>
+        <rect x="38" y="20" width="14" height="6" rx="2"/>
+      </g>
+    </g>
+
+    <!-- L tetromino, scattered bottom-right -->
+    <g transform="translate(214 128) rotate(11)">
+      <g stroke="#241f1a" stroke-width="2.4">
+        <rect x="36" y="0"  width="18" height="18" rx="3" fill="#e88c3c"/>
+        <rect x="0"  y="18" width="18" height="18" rx="3" fill="#e88c3c"/>
+        <rect x="18" y="18" width="18" height="18" rx="3" fill="#e88c3c"/>
+        <rect x="36" y="18" width="18" height="18" rx="3" fill="#e88c3c"/>
+      </g>
+      <g fill="#ffffff" fill-opacity="0.32">
+        <rect x="38" y="2"  width="14" height="6" rx="2"/>
+        <rect x="2"  y="20" width="14" height="6" rx="2"/>
+        <rect x="20" y="20" width="14" height="6" rx="2"/>
+        <rect x="38" y="20" width="14" height="6" rx="2"/>
+      </g>
+    </g>
+
+    <!-- the wordmark -->
+    <text x="160" y="126" text-anchor="middle" transform="rotate(-3 160 118)"
+          font-family="'Marker Felt','Chalkboard SE','Comic Sans MS','Segoe Print',cursive"
+          font-size="56" font-weight="700" fill="#f4f6fa">Tritris</text>
+    <!-- hand-drawn underline swoosh -->
+    <path d="M86 148 q38 12 78 6 t86 -3" fill="none" stroke="#38bed2" stroke-width="4.5" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/fun/index.html
+++ b/fun/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Fun · little browser toys · arslan.land</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="description" content="A growing wall of little things to play with in the browser — games and experiments. Inspired by neal.fun."/>
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg"/>
+  <!-- Personal (paper) theme: brings tokens + fonts. -->
+  <link rel="stylesheet" href="https://arslankazmi.github.io/ak-design/dist/personal.css"/>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; }
+    body {
+      background: var(--bg, #edece4);
+      color: var(--fg1, #1a1a1a);
+      font-family: var(--font-body, system-ui, sans-serif);
+      min-height: 100vh;
+    }
+    .wrap { max-width: 980px; margin: 0 auto; padding: 40px 22px 100px; }
+
+    /* header — just the title */
+    header.head { text-align: center; margin: 20px 0 56px; }
+    header.head h1 {
+      font-family: var(--font-display, Georgia, serif);
+      font-size: clamp(56px, 13vw, 104px); margin: 0; line-height: 0.95; letter-spacing: -0.03em;
+      color: var(--fg1, #1a1a1a);
+    }
+    header.head h1 .a { color: var(--cerulean-500, #178e8b); }
+    header.head h1 .b { color: var(--purple-500, #7a5cc9); }
+    header.head h1 .c { color: var(--seagreen-500, #3fae7a); }
+
+    /* grid of thumbnail-only tiles */
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 20px; }
+
+    a.card, .card {
+      display: block; text-decoration: none;
+      background: var(--bg-elevated, #fff); border: 1px solid var(--border, #e2ddd0);
+      border-radius: 18px; overflow: hidden;
+      box-shadow: var(--shadow-sm, 0 2px 10px rgba(0,0,0,0.06));
+      transition: transform var(--dur-med, 220ms) var(--ease-spring, cubic-bezier(.34,1.56,.64,1)), box-shadow var(--dur-med, 220ms);
+    }
+    a.card:hover { transform: translateY(-5px) rotate(-0.4deg); box-shadow: var(--shadow-lg, 0 18px 44px rgba(0,0,0,0.16)); }
+    .card .thumb { aspect-ratio: 16 / 11; background: #101218; overflow: hidden; display: block; }
+    .card .thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+
+    /* textless "coming soon" placeholders */
+    .soon { pointer-events: none; opacity: 0.85; }
+    .soon .thumb {
+      background: repeating-linear-gradient(45deg, var(--bg-sunken, #e6e0d2), var(--bg-sunken, #e6e0d2) 12px, var(--bg, #edece4) 12px, var(--bg, #edece4) 24px);
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="head">
+      <h1><span class="a">F</span><span class="b">u</span><span class="c">n</span></h1>
+    </header>
+
+    <main class="grid">
+      <!-- Tritris — the first toy -->
+      <a class="card" href="./tritris/index.html" aria-label="Tritris">
+        <span class="thumb"><img src="./assets/tritris.svg" alt="Tritris"></span>
+      </a>
+
+      <!-- placeholders: the wall keeps growing -->
+      <div class="card soon"><span class="thumb"></span></div>
+      <div class="card soon"><span class="thumb"></span></div>
+    </main>
+  </div>
+</body>
+</html>

--- a/fun/tritris/engine.js
+++ b/fun/tritris/engine.js
@@ -1,0 +1,400 @@
+/* ============================================================================
+   engine.js — Tritris core logic, a faithful port of the Python reference game
+   (arslankazmi/tritris: config.py / pieces.py / geometry.py / board.py / game.py).
+
+   Pure logic only — no DOM, no canvas, no audio. The board lives in a fixed
+   *canonical* frame (stem pointing down); "rotating the field" is a render/input
+   transform. This file is a classic script: it sets globalThis.TritrisEngine so
+   it works both as a browser <script> and via dynamic import() in the Node test.
+   ============================================================================ */
+(function () {
+  "use strict";
+
+  // --- config ---------------------------------------------------------------
+  const ARM_W = 10;      // arm width  (cross-axis) == a standard Tetris field
+  const ARM_L = 20;      // arm length (depth)      == a standard Tetris height
+  const JUNCTION = 10;   // shared central square, JUNCTION x JUNCTION
+  const WORLD_COLS = ARM_L + JUNCTION + ARM_L;   // 50
+  const WORLD_ROWS = ARM_W + ARM_L;              // 30
+
+  // Region rectangles as half-open [x0, x1, y0, y1].
+  const RECT_JUNCTION = [ARM_L, ARM_L + JUNCTION, 0, ARM_W];           // [20,30,0,10]
+  const RECT_STEM     = [ARM_L, ARM_L + JUNCTION, ARM_W, WORLD_ROWS];  // [20,30,10,30]
+  const RECT_LEFT     = [0, ARM_L, 0, ARM_W];                          // [0,20,0,10]
+  const RECT_RIGHT    = [ARM_L + JUNCTION, WORLD_COLS, 0, ARM_W];      // [30,50,0,10]
+
+  const CENTER = [ARM_L + Math.floor(JUNCTION / 2), Math.floor(ARM_W / 2)]; // [25,5]
+
+  const PIECE_COLORS = {
+    I: "#38bed2", O: "#e8c848", T: "#a860d6", S: "#60c870",
+    Z: "#de5460", J: "#4e76e0", L: "#e88c3c",
+  };
+
+  // Playfield palette (kept dark — the game's own identity, distinct from the page).
+  const COLOR = {
+    bg: "#101218", well: "#1e222c", junction: "#2c2838", grid: "#282c38",
+    text: "#e1e4eb", textDim: "#8c929e", ghost: "#464c5c", gameover: "#eb5050",
+    frame: "#464c5c",
+  };
+
+  const ROTATE_ANIM_MS = 200;
+  const BASE_FALL_MS = 800, SOFT_FALL_MS = 45, MIN_FALL_MS = 60;
+  const FALL_MS_PER_LEVEL = 65, LINES_PER_LEVEL = 10;
+  const LINE_SCORES = { 1: 100, 2: 300, 3: 500, 4: 800 };
+  const SOFT_DROP_POINTS = 1, HARD_DROP_POINTS = 2;
+
+  function fall_interval_ms(level) {
+    return Math.max(MIN_FALL_MS, BASE_FALL_MS - (level - 1) * FALL_MS_PER_LEVEL);
+  }
+
+  const C = {
+    ARM_W, ARM_L, JUNCTION, WORLD_COLS, WORLD_ROWS,
+    RECT_JUNCTION, RECT_STEM, RECT_LEFT, RECT_RIGHT, CENTER,
+    PIECE_COLORS, COLOR, ROTATE_ANIM_MS, BASE_FALL_MS, SOFT_FALL_MS,
+    MIN_FALL_MS, FALL_MS_PER_LEVEL, LINES_PER_LEVEL, LINE_SCORES,
+    SOFT_DROP_POINTS, HARD_DROP_POINTS, fall_interval_ms,
+  };
+
+  // --- pieces ---------------------------------------------------------------
+  // Spawn-state cells as [col, row] within an NxN box, with the box size N.
+  const _SPAWN = {
+    I: [4, [[0, 1], [1, 1], [2, 1], [3, 1]]],
+    O: [2, [[0, 0], [1, 0], [0, 1], [1, 1]]],
+    T: [3, [[1, 0], [0, 1], [1, 1], [2, 1]]],
+    S: [3, [[1, 0], [2, 0], [0, 1], [1, 1]]],
+    Z: [3, [[0, 0], [1, 0], [1, 1], [2, 1]]],
+    J: [3, [[0, 0], [0, 1], [1, 1], [2, 1]]],
+    L: [3, [[2, 0], [0, 1], [1, 1], [2, 1]]],
+  };
+  const SHAPES = Object.keys(_SPAWN);
+
+  function _rotate_cw(cells, n) {          // 90deg clockwise within an NxN box
+    return cells.map(([x, y]) => [n - 1 - y, x]);
+  }
+  function _sortCells(cells) {              // sort by (col, row) like Python sorted()
+    return cells.slice().sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  }
+  function _build_rotations(cells, n) {    // the 4 rotation states
+    const states = [];
+    let cur = cells;
+    for (let i = 0; i < 4; i++) { states.push(_sortCells(cur)); cur = _rotate_cw(cur, n); }
+    return states;
+  }
+  // name -> [box_size, [rot0, rot1, rot2, rot3]]
+  const ROTATIONS = {};
+  for (const name of SHAPES) {
+    const [n, cells] = _SPAWN[name];
+    ROTATIONS[name] = [n, _build_rotations(cells, n)];
+  }
+
+  class Piece {
+    constructor(name, x, y, rot = 0) {
+      this.name = name; this.x = x; this.y = y; this.rot = rot;
+      this.n = ROTATIONS[name][0];
+    }
+    cells(rot, x, y) {
+      rot = (rot === undefined || rot === null) ? this.rot : rot;
+      x = (x === undefined || x === null) ? this.x : x;
+      y = (y === undefined || y === null) ? this.y : y;
+      const box = ROTATIONS[this.name][1][((rot % 4) + 4) % 4];
+      return box.map(([cx, cy]) => [x + cx, y + cy]);
+    }
+    moved(dx, dy) { return new Piece(this.name, this.x + dx, this.y + dy, this.rot); }
+    rotated() { return new Piece(this.name, this.x, this.y, (this.rot + 1) % 4); }
+  }
+
+  // mulberry32 — small seeded PRNG so runs are reproducible for the parity test.
+  function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+      a |= 0; a = (a + 0x6D2B79F5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  class SevenBag {
+    // Standard 7-bag: emits a shuffled permutation of all 7 shapes per bag.
+    constructor(rand) { this._rand = rand || Math.random; this._bag = []; }
+    _refill() {
+      this._bag = SHAPES.slice();
+      for (let i = this._bag.length - 1; i > 0; i--) {   // Fisher-Yates
+        const j = Math.floor(this._rand() * (i + 1));
+        const t = this._bag[i]; this._bag[i] = this._bag[j]; this._bag[j] = t;
+      }
+    }
+    next() { if (this._bag.length === 0) this._refill(); return this._bag.pop(); }
+  }
+
+  // --- geometry -------------------------------------------------------------
+  const STEM_DOWN = "STEM_DOWN", RIGHT_DOWN = "RIGHT_DOWN", LEFT_DOWN = "LEFT_DOWN";
+  const ORIENTATIONS = [STEM_DOWN, RIGHT_DOWN, LEFT_DOWN];
+  const DOWN_ARM = { [STEM_DOWN]: "STEM", [RIGHT_DOWN]: "RIGHT", [LEFT_DOWN]: "LEFT" };
+  const GRAVITY = { [STEM_DOWN]: [0, 1], [RIGHT_DOWN]: [1, 0], [LEFT_DOWN]: [-1, 0] };
+  const SLIDE_LEFT = { [STEM_DOWN]: [-1, 0], [RIGHT_DOWN]: [0, 1], [LEFT_DOWN]: [0, -1] };
+  const DISPLAY_ANGLE = { [STEM_DOWN]: 0, [RIGHT_DOWN]: -90, [LEFT_DOWN]: 90 };
+  const ARM_RECT = { STEM: RECT_STEM, LEFT: RECT_LEFT, RIGHT: RECT_RIGHT };
+
+  function cycle(orientation, step) {
+    const i = ORIENTATIONS.indexOf(orientation);
+    return ORIENTATIONS[(((i + step) % 3) + 3) % 3];
+  }
+  // Field rotation follows a *linear* path LEFT — STEM — RIGHT (clamped, not cyclic):
+  // you can turn either way from the middle (stem) arm, but only back from an end arm.
+  // This avoids the jarring 180° flip straight between the two end arms.
+  const LINEAR_POS = { [LEFT_DOWN]: -1, [STEM_DOWN]: 0, [RIGHT_DOWN]: 1 };
+  const LINEAR_ORI = { "-1": LEFT_DOWN, "0": STEM_DOWN, "1": RIGHT_DOWN };
+  function step_orientation(orientation, step) {
+    const pos = Math.max(-1, Math.min(1, LINEAR_POS[orientation] + step));
+    return LINEAR_ORI[String(pos)];
+  }
+  function in_rect(x, y, rect) {
+    return rect[0] <= x && x < rect[1] && rect[2] <= y && y < rect[3];
+  }
+  function in_well(x, y, orientation) {
+    return in_rect(x, y, RECT_JUNCTION) || in_rect(x, y, ARM_RECT[DOWN_ARM[orientation]]);
+  }
+  function spawn_xy(name, orientation, n) {
+    const pad = Math.floor((ARM_W - n) / 2);      // center across the arm width
+    if (orientation === STEM_DOWN) return [ARM_L + pad, 0];
+    if (orientation === RIGHT_DOWN) return [ARM_L, pad];
+    return [ARM_L + JUNCTION - n, pad];            // LEFT_DOWN
+  }
+  function rotate_cell(x, y, orientation) {        // canonical cell -> on-screen grid
+    const [cx, cy] = CENTER, dx = x - cx, dy = y - cy;
+    let rx, ry;
+    if (orientation === STEM_DOWN) { rx = dx; ry = dy; }
+    else if (orientation === RIGHT_DOWN) { rx = -dy; ry = dx; }   // 90deg CW
+    else { rx = dy; ry = -dx; }                                    // LEFT_DOWN, 90deg CCW
+    return [cx + rx, cy + ry];
+  }
+  function rotate_about_center(x, y, angle) {      // rotate a cell by 90*k deg about junction center
+    const [cx, cy] = CENTER;
+    const px = x + 0.5 - cx, py = y + 0.5 - cy;
+    const a = ((angle % 360) + 360) % 360;
+    let rx, ry;
+    if (a === 0) { rx = px; ry = py; }
+    else if (a === 90) { rx = py; ry = -px; }
+    else if (a === 180) { rx = -px; ry = -py; }
+    else { rx = -py; ry = px; }                    // 270
+    return [Math.round(cx + rx - 0.5), Math.round(cy + ry - 0.5)];
+  }
+  function to_local(x, y, arm) {
+    if (arm === "STEM") return [x - ARM_L, y - ARM_W];
+    if (arm === "RIGHT") return [y, x - (ARM_L + JUNCTION)];
+    return [y, (ARM_L - 1) - x];                   // LEFT
+  }
+  function to_world(u, v, arm) {
+    if (arm === "STEM") return [ARM_L + u, ARM_W + v];
+    if (arm === "RIGHT") return [ARM_L + JUNCTION + v, u];
+    return [(ARM_L - 1) - v, u];                    // LEFT
+  }
+
+  const G = {
+    STEM_DOWN, RIGHT_DOWN, LEFT_DOWN, ORIENTATIONS, DOWN_ARM, GRAVITY,
+    SLIDE_LEFT, DISPLAY_ANGLE, ARM_RECT, cycle, step_orientation, in_rect, in_well, spawn_xy,
+    rotate_cell, rotate_about_center, to_local, to_world,
+  };
+
+  // --- board ----------------------------------------------------------------
+  const key = (x, y) => x + "," + y;
+
+  function _fit_piece(name, world_cells) {
+    // Reconstruct a Piece from a set of world cells that is a rigid 90deg rotation
+    // of the named tetromino. Returns null if no rotation state fits.
+    const target = new Set(world_cells.map(([x, y]) => key(x, y)));
+    const minx = Math.min(...world_cells.map(c => c[0]));
+    const miny = Math.min(...world_cells.map(c => c[1]));
+    const states = ROTATIONS[name][1];
+    for (let rot = 0; rot < 4; rot++) {
+      const box = states[rot];
+      const ox = minx - Math.min(...box.map(c => c[0]));
+      const oy = miny - Math.min(...box.map(c => c[1]));
+      const cand = new Set(box.map(([cx, cy]) => key(ox + cx, oy + cy)));
+      if (cand.size === target.size && [...cand].every(k => target.has(k))) {
+        return new Piece(name, ox, oy, rot);
+      }
+    }
+    return null;
+  }
+
+  class Board {
+    constructor() {
+      this.locked = new Map();          // "x,y" -> color
+      this.orientation = STEM_DOWN;
+    }
+    valid(piece, rot, x, y) {
+      for (const [cx, cy] of piece.cells(rot, x, y)) {
+        if (!in_well(cx, cy, this.orientation)) return false;
+        if (this.locked.has(key(cx, cy))) return false;
+      }
+      return true;
+    }
+    gravity_delta() { return GRAVITY[this.orientation]; }
+    drop_distance(piece) {
+      const [dx, dy] = this.gravity_delta();
+      let d = 0;
+      while (this.valid(piece, undefined, piece.x + dx * (d + 1), piece.y + dy * (d + 1))) d++;
+      return d;
+    }
+    lock(piece, color) {
+      for (const [cx, cy] of piece.cells()) this.locked.set(key(cx, cy), color);
+    }
+    clear_lines() {
+      // Clear full cross-lines in the active down-arm; collapse toward the floor.
+      const arm = DOWN_ARM[this.orientation];
+      const rows = [];                  // rows[v] = Map u -> color
+      for (let v = 0; v < ARM_L; v++) rows.push(new Map());
+      const armCells = [];
+      for (const [k, color] of this.locked) {
+        const [x, y] = k.split(",").map(Number);
+        if (in_rect(x, y, ARM_RECT[arm])) {
+          const [u, v] = to_local(x, y, arm);
+          rows[v].set(u, color);
+          armCells.push(k);
+        }
+      }
+      const full = [];
+      for (let v = 0; v < ARM_L; v++) if (rows[v].size === ARM_W) full.push(v);
+      if (full.length === 0) return 0;
+
+      for (const k of armCells) this.locked.delete(k);
+      const kept = [];
+      for (let v = 0; v < ARM_L; v++) if (!full.includes(v)) kept.push(rows[v]);
+      const numCleared = ARM_L - kept.length;
+      const newRows = [];
+      for (let i = 0; i < numCleared; i++) newRows.push(new Map());  // empty rows at junction side
+      for (const r of kept) newRows.push(r);
+      for (let v = 0; v < newRows.length; v++) {
+        for (const [u, color] of newRows[v]) {
+          const [wx, wy] = to_world(u, v, arm);
+          this.locked.set(key(wx, wy), color);
+        }
+      }
+      return numCleared;
+    }
+    rotate_field(step, piece) {
+      // Turn the field one step, carrying the active piece into the new down-arm
+      // while preserving its on-screen position and depth. Returns [new_o, new_piece].
+      const new_o = step_orientation(this.orientation, step);
+      if (new_o === this.orientation) return [this.orientation, piece];   // clamped at an end arm — no turn
+      if (piece === null || piece === undefined) { this.orientation = new_o; return [new_o, null]; }
+      const delta = DISPLAY_ANGLE[this.orientation] - DISPLAY_ANGLE[new_o];
+      const newCells = piece.cells().map(([x, y]) => rotate_about_center(x, y, delta));
+      const candidate = _fit_piece(piece.name, newCells);
+      const saved = this.orientation;
+      this.orientation = new_o;
+      if (candidate !== null && this.valid(candidate)) return [new_o, candidate];
+      this.orientation = saved;         // reject (like a failed wall-kick)
+      return [saved, piece];
+    }
+    spawn(name) {
+      const n = ROTATIONS[name][0];
+      const [sx, sy] = spawn_xy(name, this.orientation, n);
+      const piece = new Piece(name, sx, sy, 0);
+      return this.valid(piece) ? piece : null;
+    }
+  }
+
+  // --- game -----------------------------------------------------------------
+  class Game {
+    constructor(seed) {
+      this._rand = (seed === undefined || seed === null) ? Math.random : mulberry32(seed);
+      this.reset();
+    }
+    reset() {
+      this.board = new Board();
+      this.bag = new SevenBag(this._rand);
+      this.score = 0; this.lines = 0; this.level = 1;
+      this.paused = false; this.over = false;
+      this.events = [];                 // sound-effect events, drained by the caller
+      this.next_name = this.bag.next();
+      this.piece = null;
+      this._spawn_next();
+    }
+    _emit(name) { this.events.push(name); }
+    get color() { return this.piece ? PIECE_COLORS[this.piece.name] : null; }
+    fall_interval() { return fall_interval_ms(this.level); }
+
+    _spawn_next() {
+      const name = this.next_name;
+      this.next_name = this.bag.next();
+      const piece = this.board.spawn(name);
+      if (piece === null) { this.piece = null; this.over = true; }
+      else this.piece = piece;
+    }
+    _lock_and_advance() {
+      this.board.lock(this.piece, PIECE_COLORS[this.piece.name]);
+      this._emit("lock");
+      const cleared = this.board.clear_lines();
+      if (cleared) {
+        this.lines += cleared;
+        this.score += (LINE_SCORES[cleared] || 800) * this.level;
+        const prevLevel = this.level;
+        this.level = Math.floor(this.lines / LINES_PER_LEVEL) + 1;
+        this._emit(cleared >= 4 ? "tetris" : "clear");
+        if (this.level > prevLevel) this._emit("levelup");
+      }
+      this._spawn_next();
+      if (this.over) this._emit("gameover");
+    }
+    move_left() { this._slide(SLIDE_LEFT[this.board.orientation]); }
+    move_right() {
+      const [lx, ly] = SLIDE_LEFT[this.board.orientation];
+      this._slide([-lx, -ly]);
+    }
+    _slide(delta) {
+      if (!this._active()) return;
+      const [dx, dy] = delta;
+      const moved = this.piece.moved(dx, dy);
+      if (this.board.valid(moved)) { this.piece = moved; this._emit("move"); }
+    }
+    rotate_piece() {
+      if (!this._active()) return;
+      const rotated = this.piece.rotated();
+      for (const kick of [0, -1, 1, -2, 2]) {   // simple wall kicks along the cross-axis
+        const [lx, ly] = SLIDE_LEFT[this.board.orientation];
+        const cand = new Piece(rotated.name, rotated.x + lx * kick, rotated.y + ly * kick, rotated.rot);
+        if (this.board.valid(cand)) { this.piece = cand; this._emit("rotate"); return; }
+      }
+    }
+    rotate_field(step) {
+      if (!this._active()) return;
+      const before = this.board.orientation;
+      const [, newPiece] = this.board.rotate_field(step, this.piece);
+      this.piece = newPiece;
+      if (this.board.orientation !== before) this._emit("turn");
+    }
+    soft_drop() {
+      if (!this._active()) return;
+      if (this._step_down()) this.score += SOFT_DROP_POINTS;
+    }
+    hard_drop() {
+      if (!this._active()) return;
+      const dist = this.board.drop_distance(this.piece);
+      const [dx, dy] = this.board.gravity_delta();
+      this.piece = this.piece.moved(dx * dist, dy * dist);
+      this.score += HARD_DROP_POINTS * dist;
+      this._lock_and_advance();
+    }
+    tick_gravity() { if (this._active()) this._step_down(); }
+    toggle_pause() { if (!this.over) this.paused = !this.paused; }
+
+    _active() { return this.piece !== null && !this.over && !this.paused; }
+    _step_down() {
+      const [dx, dy] = this.board.gravity_delta();
+      const moved = this.piece.moved(dx, dy);
+      if (this.board.valid(moved)) { this.piece = moved; return true; }
+      this._lock_and_advance();
+      return false;
+    }
+  }
+
+  const TritrisEngine = {
+    C, PIECE_COLORS, COLOR, fall_interval_ms,
+    SHAPES, ROTATIONS, Piece, SevenBag, mulberry32,
+    G, Board, _fit_piece, Game, key,
+  };
+  if (typeof globalThis !== "undefined") globalThis.TritrisEngine = TritrisEngine;
+})();

--- a/fun/tritris/index.html
+++ b/fun/tritris/index.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Tritris · a T-shaped Tetris · arslan.land</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
+  <meta name="description" content="Tritris — a Tetris twist on a T-shaped playfield. Rotate the whole board, not the piece; fill three arms without jamming the junction. Plays in your browser."/>
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg"/>
+  <!-- Personal (paper) theme: fonts + tokens for the page chrome. The playfield keeps its own dark palette. -->
+  <link rel="stylesheet" href="https://arslankazmi.github.io/ak-design/dist/personal.css"/>
+  <style>
+    :root { --pf: #101218; }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; }
+    body {
+      background: var(--bg, #edece4);
+      color: var(--fg1, #1a1a1a);
+      font-family: var(--font-body, system-ui, sans-serif);
+      min-height: 100vh;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: manipulation;
+    }
+    .wrap { max-width: 1000px; margin: 0 auto; padding: 16px 16px 40px; }
+
+    .topbar { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; flex-wrap: wrap; }
+    .topbar .brand { display: flex; align-items: baseline; gap: 10px; margin-right: auto; }
+    .topbar h1 {
+      font-family: var(--font-display, Georgia, serif);
+      font-size: clamp(24px, 5vw, 34px); margin: 0; letter-spacing: -0.02em; line-height: 1;
+    }
+    .topbar .tag { font-family: var(--font-mono, monospace); font-size: 12px; color: var(--fg2, #666); }
+    .topbar .sp { flex: 0 0 auto; }
+    .iconbtn, .textbtn {
+      font-family: var(--font-mono, monospace); font-size: 13px;
+      border: 1px solid var(--border-strong, #cfc9bb); background: var(--bg-elevated, #fff);
+      color: var(--fg1, #1a1a1a); border-radius: 10px; padding: 8px 12px; cursor: pointer;
+      transition: transform var(--dur-fast, 120ms), background var(--dur-fast, 120ms);
+    }
+    .iconbtn:hover, .textbtn:hover { transform: translateY(-1px); background: var(--accent-soft, #e8f3f2); }
+    .topbar a.textbtn { text-decoration: none; }
+
+    .stage { display: flex; gap: 20px; align-items: flex-start; flex-wrap: wrap; justify-content: center; }
+    .boardbox {
+      position: relative; background: var(--pf); border-radius: 16px; padding: 10px;
+      box-shadow: var(--shadow-lg, 0 12px 40px rgba(0,0,0,0.18));
+      border: 1px solid rgba(0,0,0,0.15);
+      flex: 1 1 460px; max-width: 680px;
+      display: flex; justify-content: center;
+    }
+    canvas#play { display: block; width: 100%; height: auto; border-radius: 8px; }
+    /* Zoomed mode uses a tall portrait canvas; hug it and constrain by height so a
+       single arm fills the frame without exploding the page vertically. */
+    .boardbox.zoomed { flex: 0 0 auto; max-width: 100%; }
+    .boardbox.zoomed canvas#play { width: auto; height: min(76vh, 720px); max-width: 100%; }
+
+    /* HUD */
+    .hud { flex: 0 0 200px; display: flex; flex-direction: column; gap: 14px; min-width: 170px; }
+    .card {
+      background: var(--bg-elevated, #fff); border: 1px solid var(--border, #e2ddd0);
+      border-radius: 14px; padding: 14px 16px; box-shadow: var(--shadow-sm, 0 2px 8px rgba(0,0,0,0.06));
+    }
+    .stat { display: flex; justify-content: space-between; align-items: baseline; margin: 4px 0; }
+    .stat .k { font-family: var(--font-mono, monospace); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg3, #999); }
+    .stat .v { font-family: var(--font-display, Georgia, serif); font-size: 26px; font-weight: 700; }
+    .nextwrap { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+    .nextwrap .k { font-family: var(--font-mono, monospace); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg3, #999); align-self: flex-start; }
+    canvas#next { width: 110px; height: 88px; border-radius: 8px; }
+    .legend { font-family: var(--font-mono, monospace); font-size: 11px; line-height: 1.7; color: var(--fg2, #666); }
+    .legend b { color: var(--fg1, #1a1a1a); font-weight: 600; }
+
+    /* overlays */
+    .overlay {
+      position: absolute; inset: 10px; border-radius: 8px; z-index: 5;
+      display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center;
+      background: rgba(10, 12, 18, 0.9); color: #e1e4eb; padding: 24px; gap: 12px;
+      backdrop-filter: blur(3px);
+    }
+    .overlay.hidden { display: none; }
+    .overlay h2 { font-family: var(--font-display, Georgia, serif); margin: 0; font-size: clamp(28px, 6vw, 44px); color: #fff; }
+    .overlay p { margin: 0; font-family: var(--font-mono, monospace); font-size: 13px; color: #b7bdca; max-width: 30ch; line-height: 1.6; }
+    .overlay .keys { display: grid; grid-template-columns: auto 1fr; gap: 4px 14px; font-family: var(--font-mono, monospace); font-size: 12px; color: #cdd2dd; text-align: left; margin: 4px 0; }
+    .overlay .keys b { color: #fff; }
+    .overlay .start { font-family: var(--font-mono, monospace); font-size: 13px; color: #8ee6c9; margin-top: 6px; }
+    .overlay .primary {
+      font-family: var(--font-mono, monospace); font-size: 14px; border: 0; cursor: pointer;
+      background: #178e8b; color: #fff; border-radius: 10px; padding: 10px 20px; margin-top: 6px;
+    }
+
+    /* touch controls */
+    .controls { margin-top: 18px; display: flex; gap: 16px; justify-content: center; align-items: center; flex-wrap: wrap; }
+    .cluster { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+    .cluster .lab { font-family: var(--font-mono, monospace); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg3, #999); }
+    .cluster .row { display: flex; gap: 8px; }
+    .pad {
+      width: 56px; height: 56px; border-radius: 14px; border: 1px solid var(--border-strong, #cfc9bb);
+      background: var(--bg-elevated, #fff); color: var(--fg1, #1a1a1a); font-size: 22px; cursor: pointer;
+      display: flex; align-items: center; justify-content: center; user-select: none;
+      box-shadow: var(--shadow-sm, 0 2px 8px rgba(0,0,0,0.06)); transition: transform var(--dur-fast, 120ms), background var(--dur-fast, 120ms);
+    }
+    .pad:active { transform: translateY(2px); background: var(--accent-soft, #e8f3f2); }
+    .pad.turn { border-color: var(--accent, #178e8b); color: var(--accent, #178e8b); }
+
+    footer.foot { margin-top: 30px; text-align: center; font-family: var(--font-mono, monospace); font-size: 12px; color: var(--fg2, #666); }
+    footer.foot a { color: var(--accent, #178e8b); }
+
+    @media (max-width: 560px) {
+      .pad { width: 50px; height: 50px; font-size: 20px; }
+      .hud { flex-basis: 100%; flex-direction: row; flex-wrap: wrap; }
+      .card { flex: 1 1 120px; }
+      .legend { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="topbar">
+      <div class="brand">
+        <h1>Tritris</h1>
+        <span class="tag">rotate the board, not the piece</span>
+      </div>
+      <button id="viewBtn" class="textbtn" title="Toggle full / zoomed view (V)">▦ full</button>
+      <button id="muteBtn" class="iconbtn" title="Mute (M)" aria-pressed="false">🔊</button>
+      <a class="textbtn" href="../index.html">← Fun</a>
+    </div>
+
+    <div class="stage">
+      <div class="boardbox">
+        <canvas id="play" width="640" height="640"></canvas>
+
+        <div id="titleOverlay" class="overlay">
+          <h2>Tritris</h2>
+          <p>Three arms, one shared junction. Pieces fall into whichever arm points down — <b>rotate the whole field</b> to aim.</p>
+          <div class="keys">
+            <b>← →</b><span>move piece</span>
+            <b>↑ / W</b><span>rotate piece</span>
+            <b>↓ / S</b><span>soft drop</span>
+            <b>Space</b><span>hard drop</span>
+            <b>Shift + ← →</b><span>rotate the field</span>
+            <b>V</b><span>full / zoomed view</span>
+            <b>Tab · M · P</b><span>minimap · mute · pause</span>
+          </div>
+          <div class="start">press any key or tap to start</div>
+        </div>
+
+        <div id="overOverlay" class="overlay hidden">
+          <h2>Pieces crossed</h2>
+          <p>A stack backed up into the junction. Final score <b id="finalScore">0</b>.</p>
+          <button id="restartBtn" class="primary">Play again (R)</button>
+        </div>
+
+        <div id="pauseOverlay" class="overlay hidden">
+          <h2>Paused</h2>
+          <p>Press P to resume.</p>
+        </div>
+      </div>
+
+      <div class="hud">
+        <div class="card">
+          <div class="stat"><span class="k">Score</span><span class="v" id="score">0</span></div>
+          <div class="stat"><span class="k">Level</span><span class="v" id="level">1</span></div>
+          <div class="stat"><span class="k">Lines</span><span class="v" id="lines">0</span></div>
+        </div>
+        <div class="card nextwrap">
+          <span class="k">Next</span>
+          <canvas id="next" width="110" height="88"></canvas>
+        </div>
+        <div class="card legend">
+          <b>Shift + ← →</b> turns the field<br>
+          <b>V</b> full / zoomed &nbsp; <b>Tab</b> minimap<br>
+          <b>↑</b> rotate &nbsp; <b>Space</b> hard drop<br>
+          <b>M</b> mute &nbsp; <b>P</b> pause &nbsp; <b>R</b> restart
+        </div>
+      </div>
+    </div>
+
+    <!-- On-screen controls (touch + click). -->
+    <div class="controls">
+      <div class="cluster">
+        <span class="lab">turn field</span>
+        <div class="row">
+          <button class="pad turn" id="btn-turnL" aria-label="Rotate field counter-clockwise">↺</button>
+          <button class="pad turn" id="btn-turnR" aria-label="Rotate field clockwise">↻</button>
+        </div>
+      </div>
+      <div class="cluster">
+        <span class="lab">move</span>
+        <div class="row">
+          <button class="pad" id="btn-left" aria-label="Move left">◀</button>
+          <button class="pad" id="btn-soft" aria-label="Soft drop">▼</button>
+          <button class="pad" id="btn-right" aria-label="Move right">▶</button>
+        </div>
+      </div>
+      <div class="cluster">
+        <span class="lab">piece</span>
+        <div class="row">
+          <button class="pad" id="btn-rotate" aria-label="Rotate piece">⟳</button>
+          <button class="pad" id="btn-hard" aria-label="Hard drop">⤓</button>
+        </div>
+      </div>
+    </div>
+
+    <footer class="foot">
+      A native HTML5 port of <a href="https://github.com/arslankazmi/tritris">Tritris</a> — the
+      Python/Pygame original. Part of <a href="../index.html">Fun</a>.
+    </footer>
+  </div>
+
+  <script src="engine.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/fun/tritris/main.js
+++ b/fun/tritris/main.js
@@ -1,0 +1,433 @@
+/* ============================================================================
+   main.js — browser frontend for Tritris: canvas renderer (animated rotating-T
+   + zoomed single-arm view + minimap), keyboard + touch input, WebAudio chiptune,
+   and the game loop. Depends on engine.js (window.TritrisEngine).
+
+   Rendering: the board is drawn in the canonical frame inside one canvas transform
+   (translate to the junction-center pivot, rotate by the animated display angle,
+   scale to cells). The active piece + ghost are drawn at the *target* angle so they
+   hold their screen position in the down-well while the board sweeps during a turn.
+   Canvas rotation theta = -displayAngle (rad): see engine.rotate_cell for why.
+   ============================================================================ */
+(function () {
+  "use strict";
+  const E = window.TritrisEngine;
+  const { C, G, PIECE_COLORS, COLOR, ROTATIONS } = E;
+  const DEG = Math.PI / 180;
+  const [CX, CY] = C.CENTER;
+
+  // --- elements -------------------------------------------------------------
+  const canvas = document.getElementById("play");
+  const ctx = canvas.getContext("2d");
+  const nextCanvas = document.getElementById("next");
+  const nextCtx = nextCanvas.getContext("2d");
+  const elScore = document.getElementById("score");
+  const elLevel = document.getElementById("level");
+  const elLines = document.getElementById("lines");
+  const elTitle = document.getElementById("titleOverlay");
+  const elOver = document.getElementById("overOverlay");
+  const elFinal = document.getElementById("finalScore");
+  const elPause = document.getElementById("pauseOverlay");
+  const elMute = document.getElementById("muteBtn");
+  const elView = document.getElementById("viewBtn");
+
+  const VIEW = { FULL: "full", ZOOMED: "zoomed" };
+
+  const game = new E.Game();
+  let scene = "title";                 // "title" -> "play"
+  let view = VIEW.FULL;
+  let showMinimap = false;
+  let softHeld = false;
+
+  const boardbox = document.querySelector(".boardbox");
+  // The two views want different canvas shapes: FULL needs a square (the rotating T
+  // spans ~52 cells each way); ZOOMED wants a tall portrait so one 10x30 arm fills the
+  // frame edge-to-edge at ~pygame's 24px cell instead of sitting as a narrow strip.
+  function applyViewLayout() {
+    if (view === VIEW.ZOOMED) {
+      canvas.width = 264; canvas.height = 720;      // 11:30 — the arm fills the width
+      boardbox.classList.add("zoomed");
+    } else {
+      canvas.width = 720; canvas.height = 720;
+      boardbox.classList.remove("zoomed");
+    }
+  }
+
+  // --- rotation animation (port of main.py RotationAnim) --------------------
+  function shortestDelta(from, to) {
+    let d = to - from;
+    while (d <= -180) d += 360;
+    while (d > 180) d -= 360;
+    return d;
+  }
+  const anim = {
+    angle: 0, _start: 0, _delta: 0, _t0: 0, _active: false,
+    startTo(target, now) {
+      this._start = this.angle;
+      this._delta = shortestDelta(this.angle, target);
+      this._t0 = now;
+      this._active = this._delta !== 0;
+    },
+    update(now) {
+      if (!this._active) return;
+      let t = (now - this._t0) / C.ROTATE_ANIM_MS;
+      if (t >= 1) { this.angle = this._start + this._delta; this._active = false; }
+      else { t = t * t * (3 - 2 * t); this.angle = this._start + this._delta * t; }  // smoothstep
+    },
+  };
+  function syncAnim() { anim.startTo(G.DISPLAY_ANGLE[game.board.orientation], performance.now()); }
+
+  // --- sound (WebAudio port of engine's SFX table) --------------------------
+  const WAVE = { sq: "square", tri: "triangle", sin: "sine" };
+  const SFX = {
+    move: [[440, 22, "sq", 0.22]],
+    rotate: [[620, 22, "sq", 0.22]],
+    lock: [[150, 55, "sq", 0.33]],
+    turn: [[300, 45, "tri", 0.28], [600, 55, "tri", 0.28]],
+    clear: [[523, 55, "sq", 0.30], [659, 55, "sq", 0.30], [784, 80, "sq", 0.30]],
+    tetris: [[523, 55, "sq", 0.33], [659, 55, "sq", 0.33], [784, 55, "sq", 0.33], [1047, 130, "sq", 0.33]],
+    levelup: [[659, 55, "sq", 0.30], [988, 55, "sq", 0.30], [1319, 130, "sq", 0.30]],
+    gameover: [[392, 130, "tri", 0.32], [311, 130, "tri", 0.32], [233, 320, "tri", 0.32]],
+  };
+  const sound = {
+    ctx: null, master: null, muted: false,
+    ensure() {
+      if (this.ctx) return;
+      const AC = window.AudioContext || window.webkitAudioContext;
+      if (!AC) return;
+      this.ctx = new AC();
+      this.master = this.ctx.createGain();
+      this.master.gain.value = 0.6;
+      this.master.connect(this.ctx.destination);
+    },
+    play(name) {
+      if (this.muted) return;
+      this.ensure();
+      if (!this.ctx) return;
+      if (this.ctx.state === "suspended") this.ctx.resume();
+      const segs = SFX[name];
+      if (!segs) return;
+      let t = this.ctx.currentTime + 0.001;
+      for (const [freq, ms, wave, vol] of segs) {
+        const dur = ms / 1000;
+        if (freq > 0) {
+          const osc = this.ctx.createOscillator();
+          const g = this.ctx.createGain();
+          osc.type = WAVE[wave] || "square";
+          osc.frequency.value = freq;
+          g.gain.setValueAtTime(vol, t);
+          g.gain.linearRampToValueAtTime(0.0001, t + dur);   // linear decay, like the Python envelope
+          osc.connect(g); g.connect(this.master);
+          osc.start(t); osc.stop(t + dur);
+        }
+        t += dur;
+      }
+    },
+    toggleMute() {
+      this.muted = !this.muted;
+      elMute.textContent = this.muted ? "🔇" : "🔊";
+      elMute.setAttribute("aria-pressed", String(this.muted));
+      return this.muted;
+    },
+  };
+
+  // --- drawing helpers ------------------------------------------------------
+  function roundRectPath(g, x, y, w, h, r) {
+    r = Math.min(r, w / 2, h / 2);
+    g.beginPath();
+    g.moveTo(x + r, y);
+    g.arcTo(x + w, y, x + w, y + h, r);
+    g.arcTo(x + w, y + h, x, y + h, r);
+    g.arcTo(x, y + h, x, y, r);
+    g.arcTo(x, y, x + w, y, r);
+    g.closePath();
+  }
+
+  // Establish the canonical->screen transform for a given view + angle.
+  // After this, 1 unit == 1 cell and canonical cell (x,y) draws at rect(x,y,1,1).
+  function setBoardTransform(g, angleDeg, s, pivotX, pivotY) {
+    g.translate(pivotX, pivotY);
+    g.rotate(-angleDeg * DEG);
+    g.scale(s, s);
+    g.translate(-CX, -CY);
+  }
+
+  function drawCell(g, x, y, color) {
+    g.fillStyle = color;
+    g.fillRect(x + 0.04, y + 0.04, 0.92, 0.92);
+    g.fillStyle = "rgba(255,255,255,0.10)";
+    g.fillRect(x + 0.04, y + 0.04, 0.92, 0.22);           // top highlight
+  }
+
+  function drawWellsAndLocked(g) {
+    const rects = [
+      [C.RECT_LEFT, COLOR.well], [C.RECT_RIGHT, COLOR.well],
+      [C.RECT_STEM, COLOR.well], [C.RECT_JUNCTION, COLOR.junction],
+    ];
+    for (const [r, col] of rects) {
+      g.fillStyle = col;
+      g.fillRect(r[0], r[2], r[1] - r[0], r[3] - r[2]);
+    }
+    // grid lines
+    g.strokeStyle = COLOR.grid;
+    g.lineWidth = 0.03;
+    for (const r of [C.RECT_LEFT, C.RECT_RIGHT, C.RECT_STEM, C.RECT_JUNCTION]) {
+      for (let x = r[0]; x <= r[1]; x++) { g.beginPath(); g.moveTo(x, r[2]); g.lineTo(x, r[3]); g.stroke(); }
+      for (let y = r[2]; y <= r[3]; y++) { g.beginPath(); g.moveTo(r[0], y); g.lineTo(r[1], y); g.stroke(); }
+    }
+    for (const [k, color] of game.board.locked) {
+      const [x, y] = k.split(",").map(Number);
+      drawCell(g, x, y, color);
+    }
+  }
+
+  function drawPieceLayer(g) {
+    if (!game.piece) return;
+    const color = PIECE_COLORS[game.piece.name];
+    // ghost
+    const dist = game.board.drop_distance(game.piece);
+    const [gdx, gdy] = game.board.gravity_delta();
+    if (dist > 0) {
+      g.strokeStyle = COLOR.ghost;
+      g.lineWidth = 0.08;
+      for (const [x, y] of game.piece.cells()) {
+        g.strokeRect(x + gdx * dist + 0.1, y + gdy * dist + 0.1, 0.8, 0.8);
+      }
+    }
+    for (const [x, y] of game.piece.cells()) drawCell(g, x, y, color);
+  }
+
+  // Outer corners of the T silhouette (bar rect 0..50 x 0..10, stem rect 20..30 x 10..30),
+  // in canonical cell coords — used to frame the full view tightly per orientation.
+  const T_CORNERS = [[0, 0], [50, 0], [50, 10], [0, 10], [20, 10], [30, 10], [30, 30], [20, 30]];
+
+  // Render one board instance into a screen rectangle with an optional clip.
+  function renderInstance(mode, rx, ry, rw, rh) {
+    let s, pivotX, pivotY;
+    if (mode === VIEW.FULL) {
+      // Fit the T's *rotated* bounding box into the box so it fills the frame in whatever
+      // orientation it's in (instead of a small shape floating in a big square, centered on
+      // the junction). Recomputed from the animated angle each frame, so it stays framed
+      // as the field turns. Board + piece share this frame, so the piece holds position.
+      const th = -anim.angle * DEG, cos = Math.cos(th), sin = Math.sin(th);
+      let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+      for (const [px, py] of T_CORNERS) {
+        const dx = px - CX, dy = py - CY;
+        const ux = dx * cos - dy * sin, uy = dx * sin + dy * cos;
+        if (ux < minX) minX = ux; if (ux > maxX) maxX = ux;
+        if (uy < minY) minY = uy; if (uy > maxY) maxY = uy;
+      }
+      const pad = Math.min(rw, rh) * 0.02;
+      s = Math.min((rw - 2 * pad) / (maxX - minX), (rh - 2 * pad) / (maxY - minY));
+      pivotX = rx + rw / 2 - ((minX + maxX) / 2) * s;
+      pivotY = ry + rh / 2 - ((minY + maxY) / 2) * s;
+    } else {                                     // ZOOMED: the down-well (10x30) fills the frame at ~pygame's 24px cell
+      s = Math.min(rw / 10.3, rh / 30.4);
+      pivotX = rx + rw / 2; pivotY = ry + 5.2 * s;
+    }
+    ctx.save();
+    ctx.beginPath(); ctx.rect(rx, ry, rw, rh); ctx.clip();
+    // board (sweeps at the animated angle)
+    ctx.save();
+    setBoardTransform(ctx, anim.angle, s, pivotX, pivotY);
+    drawWellsAndLocked(ctx);
+    ctx.restore();
+    // active piece + ghost (held at the target angle so they stay in the well)
+    ctx.save();
+    setBoardTransform(ctx, G.DISPLAY_ANGLE[game.board.orientation], s, pivotX, pivotY);
+    drawPieceLayer(ctx);
+    ctx.restore();
+    ctx.restore();
+  }
+
+  function render() {
+    ctx.fillStyle = COLOR.bg;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const W = canvas.width, H = canvas.height;
+    renderInstance(view, 0, 0, W, H);
+    if (view === VIEW.ZOOMED && showMinimap) {
+      const m = Math.round(Math.min(W, H) * 0.26);
+      const pad = 10;
+      ctx.save();
+      ctx.fillStyle = "rgba(8,10,14,0.82)";
+      roundRectPath(ctx, W - m - pad, pad, m, m, 8);
+      ctx.fill();
+      ctx.strokeStyle = COLOR.frame; ctx.lineWidth = 1; ctx.stroke();
+      ctx.restore();
+      renderInstance(VIEW.FULL, W - m - pad, pad, m, m);
+    }
+  }
+
+  // Next-piece preview.
+  function renderNext() {
+    const g = nextCtx, w = nextCanvas.width, h = nextCanvas.height;
+    g.fillStyle = COLOR.well;
+    g.clearRect(0, 0, w, h);
+    roundRectPath(g, 0, 0, w, h, 8); g.fillStyle = COLOR.well; g.fill();
+    const name = game.next_name;
+    if (!name) return;
+    const [n, states] = ROTATIONS[name];
+    const cells = states[0];
+    const s = Math.min(w, h) / 5;
+    const minx = Math.min(...cells.map(c => c[0])), maxx = Math.max(...cells.map(c => c[0]));
+    const miny = Math.min(...cells.map(c => c[1])), maxy = Math.max(...cells.map(c => c[1]));
+    const ox = (w - (maxx - minx + 1) * s) / 2 - minx * s;
+    const oy = (h - (maxy - miny + 1) * s) / 2 - miny * s;
+    g.save(); g.translate(ox, oy); g.scale(s, s);
+    for (const [cx, cy] of cells) drawCell(g, cx, cy, PIECE_COLORS[name]);
+    g.restore();
+  }
+
+  function updateHUD() {
+    elScore.textContent = game.score;
+    elLevel.textContent = game.level;
+    elLines.textContent = game.lines;
+    renderNext();
+  }
+
+  // --- input ----------------------------------------------------------------
+  function shiftHeld(e) { return e.shiftKey; }
+
+  function doTurn(step) {
+    const before = game.board.orientation;
+    game.rotate_field(step);
+    if (game.board.orientation !== before) anim.startTo(G.DISPLAY_ANGLE[game.board.orientation], performance.now());
+  }
+
+  const KEY_ACTION = {
+    ArrowLeft: "left", KeyA: "left",
+    ArrowRight: "right", KeyD: "right",
+    ArrowUp: "rotate", KeyW: "rotate",
+    ArrowDown: "soft", KeyS: "soft",
+    Space: "hard",
+    KeyV: "view", Tab: "minimap", KeyM: "mute", KeyP: "pause", KeyR: "restart",
+  };
+
+  function startGame() {
+    scene = "play";
+    elTitle.classList.add("hidden");
+    game.reset();
+    syncAnim();
+    softHeld = false;
+  }
+
+  function restart() {
+    game.reset();
+    elOver.classList.add("hidden");
+    scene = "play";
+    syncAnim();
+  }
+
+  function onKeyDown(e) {
+    sound.ensure();
+    if (scene === "title") {
+      if (e.code === "Escape") return;
+      e.preventDefault();
+      startGame();
+      return;
+    }
+    const action = KEY_ACTION[e.code];
+    if (!action) return;
+    e.preventDefault();
+
+    if ((action === "left" || action === "right") && shiftHeld(e)) {
+      doTurn(action === "left" ? -1 : +1);
+      return;
+    }
+    switch (action) {
+      case "left": game.move_left(); break;
+      case "right": game.move_right(); break;
+      case "rotate": game.rotate_piece(); break;
+      case "soft": softHeld = true; game.soft_drop(); break;
+      case "hard": game.hard_drop(); break;
+      case "view": toggleView(); break;
+      case "minimap": showMinimap = !showMinimap; break;
+      case "mute": sound.toggleMute(); break;
+      case "pause": game.toggle_pause(); elPause.classList.toggle("hidden", !game.paused); break;
+      case "restart": restart(); break;
+    }
+  }
+  function onKeyUp(e) {
+    if (KEY_ACTION[e.code] === "soft") softHeld = false;
+  }
+
+  function toggleView() {
+    view = view === VIEW.FULL ? VIEW.ZOOMED : VIEW.FULL;
+    elView.textContent = view === VIEW.ZOOMED ? "◱ zoomed" : "▦ full";
+    applyViewLayout();
+  }
+
+  // On-screen touch controls (also clickable with a mouse).
+  function bindHold(id, downFn, upFn) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const down = (e) => { e.preventDefault(); sound.ensure(); if (scene === "title") { startGame(); return; } downFn(); };
+    const up = (e) => { if (e) e.preventDefault(); if (upFn) upFn(); };
+    el.addEventListener("pointerdown", down);
+    el.addEventListener("pointerup", up);
+    el.addEventListener("pointerleave", up);
+    el.addEventListener("pointercancel", up);
+  }
+  function bindTap(id, fn) { bindHold(id, fn, null); }
+
+  bindTap("btn-left", () => game.move_left());
+  bindTap("btn-right", () => game.move_right());
+  bindTap("btn-rotate", () => game.rotate_piece());
+  bindTap("btn-hard", () => game.hard_drop());
+  bindTap("btn-turnL", () => doTurn(-1));
+  bindTap("btn-turnR", () => doTurn(+1));
+  bindHold("btn-soft", () => { softHeld = true; game.soft_drop(); }, () => { softHeld = false; });
+
+  elMute.addEventListener("click", () => { sound.ensure(); sound.toggleMute(); });
+  elView.addEventListener("click", toggleView);
+  document.getElementById("restartBtn").addEventListener("click", restart);
+  elTitle.addEventListener("pointerdown", (e) => { e.preventDefault(); sound.ensure(); startGame(); });
+
+  window.addEventListener("keydown", onKeyDown);
+  window.addEventListener("keyup", onKeyUp);
+
+  // --- loop -----------------------------------------------------------------
+  let last = performance.now();
+  let acc = 0;
+  let wasOver = false;
+  function frame(now) {
+    anim.update(now);
+    if (scene === "play" && !game.paused && !game.over) {
+      const dt = now - last;
+      acc += dt;
+      const interval = softHeld ? C.SOFT_FALL_MS : game.fall_interval();
+      let guard = 0;
+      while (acc >= interval && guard < 8) {
+        if (softHeld) game.soft_drop(); else game.tick_gravity();
+        acc -= interval;
+        guard++;
+        if (game.over) break;
+      }
+    } else {
+      acc = 0;
+    }
+    last = now;
+
+    for (const name of game.events) sound.play(name);
+    game.events.length = 0;
+
+    if (game.over && !wasOver) {
+      wasOver = true;
+      elFinal.textContent = game.score;
+      elOver.classList.remove("hidden");
+    }
+    if (!game.over) wasOver = false;
+
+    render();
+    updateHUD();
+    requestAnimationFrame(frame);
+  }
+
+  // init HUD/labels and go
+  elView.textContent = "▦ full";
+  elMute.textContent = "🔊";
+  applyViewLayout();
+  updateHUD();
+  render();
+  requestAnimationFrame(frame);
+})();

--- a/fun/tritris/test.mjs
+++ b/fun/tritris/test.mjs
@@ -1,0 +1,195 @@
+/* ============================================================================
+   test.mjs — parity checks for the JS Tritris port against the Python reference
+   (mirrors tritris/tests/test_logic.py). Run: `node fun/tritris/test.mjs`.
+   This file is *.mjs so the site build prunes it from the published tree.
+   ============================================================================ */
+import "./engine.js";
+const E = globalThis.TritrisEngine;
+const { C, G, SHAPES, ROTATIONS, Piece, SevenBag, mulberry32, Board, Game, key } = E;
+
+let passed = 0;
+const fails = [];
+function ok(cond, msg) { if (cond) passed++; else fails.push(msg); }
+function eq(a, b, msg) { ok(a === b, `${msg} (got ${a}, want ${b})`); }
+
+// --- pieces ------------------------------------------------------------------
+{
+  const bag = new SevenBag(mulberry32(0));
+  const first = Array.from({ length: 7 }, () => bag.next()).sort();
+  const second = Array.from({ length: 7 }, () => bag.next()).sort();
+  ok(JSON.stringify(first) === JSON.stringify(SHAPES.slice().sort()), "7-bag first bag = all 7");
+  ok(JSON.stringify(second) === JSON.stringify(SHAPES.slice().sort()), "7-bag second bag = all 7");
+}
+for (const name of SHAPES) {
+  for (const cells of ROTATIONS[name][1]) eq(cells.length, 4, `${name} rotation has 4 cells`);
+}
+
+// --- geometry ----------------------------------------------------------------
+eq(G.cycle(G.STEM_DOWN, 1), G.RIGHT_DOWN, "cycle STEM+1");
+eq(G.cycle(G.RIGHT_DOWN, 1), G.LEFT_DOWN, "cycle RIGHT+1");
+eq(G.cycle(G.LEFT_DOWN, 1), G.STEM_DOWN, "cycle LEFT+1");
+eq(G.cycle(G.STEM_DOWN, -1), G.LEFT_DOWN, "cycle STEM-1");
+
+for (const arm of ["STEM", "LEFT", "RIGHT"]) {
+  const [x0, x1, y0, y1] = G.ARM_RECT[arm];
+  for (let x = x0; x < x1; x++) for (let y = y0; y < y1; y++) {
+    const [u, v] = G.to_local(x, y, arm);
+    ok(u >= 0 && u < C.ARM_W && v >= 0 && v < C.ARM_L, `to_local in range ${arm} ${x},${y}`);
+    const [wx, wy] = G.to_world(u, v, arm);
+    ok(wx === x && wy === y, `local/world round-trip ${arm} ${x},${y}`);
+  }
+}
+
+// far end of each active arm points screen-south (largest screen-y).
+for (const o of G.ORIENTATIONS) {
+  const arm = G.DOWN_ARM[o];
+  const floor = G.to_world(0, C.ARM_L - 1, arm);
+  const jEnd = G.to_world(0, 0, arm);
+  const fy = G.rotate_cell(floor[0], floor[1], o)[1];
+  const jy = G.rotate_cell(jEnd[0], jEnd[1], o)[1];
+  ok(fy > jy, `${o}: floor below junction end on screen`);
+}
+
+// field rotation maps old well onto new well (so a legal piece is never wrongly rejected).
+function wellCells(o) {
+  const cells = new Set();
+  for (const rect of [C.RECT_JUNCTION, G.ARM_RECT[G.DOWN_ARM[o]]]) {
+    const [x0, x1, y0, y1] = rect;
+    for (let x = x0; x < x1; x++) for (let y = y0; y < y1; y++) cells.add(key(x, y));
+  }
+  return cells;
+}
+for (const step of [1, -1]) for (const o of G.ORIENTATIONS) {
+  const newO = G.cycle(o, step);
+  const delta = G.DISPLAY_ANGLE[o] - G.DISPLAY_ANGLE[newO];
+  const newWell = wellCells(newO);
+  for (const k of wellCells(o)) {
+    const [x, y] = k.split(",").map(Number);
+    const [rx, ry] = G.rotate_about_center(x, y, delta);
+    ok(newWell.has(key(rx, ry)), `well maps onto new well o=${o} step=${step} cell=${k}`);
+  }
+}
+
+// --- board line clears -------------------------------------------------------
+function fillRow(board, arm, v) {
+  for (let u = 0; u < C.ARM_W; u++) {
+    const [x, y] = G.to_world(u, v, arm);
+    board.locked.set(key(x, y), "#fff");
+  }
+}
+for (const o of G.ORIENTATIONS) {
+  const board = new Board();
+  board.orientation = o;
+  const arm = G.DOWN_ARM[o];
+  fillRow(board, arm, C.ARM_L - 1);
+  const [mx, my] = G.to_world(2, C.ARM_L - 2, arm);
+  board.locked.set(key(mx, my), "#999");
+  const cleared = board.clear_lines();
+  eq(cleared, 1, `${o}: one line cleared`);
+  const [fx, fy] = G.to_world(2, C.ARM_L - 1, arm);
+  ok(board.locked.has(key(fx, fy)) && board.locked.get(key(fx, fy)) === "#999",
+     `${o}: marker fell to floor`);
+}
+
+// clearing the active arm must not touch a frozen arm.
+{
+  const board = new Board();
+  board.orientation = G.STEM_DOWN;
+  fillRow(board, "LEFT", C.ARM_L - 1);
+  fillRow(board, "STEM", C.ARM_L - 1);
+  board.clear_lines();
+  const [lx, ly] = G.to_world(0, C.ARM_L - 1, "LEFT");
+  ok(board.locked.has(key(lx, ly)), "frozen LEFT arm untouched by STEM clear");
+}
+
+// --- spawn / game over -------------------------------------------------------
+{
+  const board = new Board();
+  board.orientation = G.STEM_DOWN;
+  const [x0, x1, y0, y1] = C.RECT_JUNCTION;
+  for (let x = x0; x < x1; x++) for (let y = y0; y < y1; y++) board.locked.set(key(x, y), "#fff");
+  ok(board.spawn("O") === null, "spawn blocked when junction full");
+}
+{
+  const board = new Board();
+  const piece = board.spawn("T");
+  ok(piece !== null, "T spawns");
+  const [newO, newPiece] = board.rotate_field(1, piece);
+  eq(newO, G.RIGHT_DOWN, "rotate_field(1) -> RIGHT_DOWN");
+  ok(board.valid(newPiece), "rotated piece is valid in new arm");
+}
+
+// --- linear (clamped) field rotation: no 180° flip between end arms ----------
+eq(G.step_orientation(G.STEM_DOWN, 1), G.RIGHT_DOWN, "middle +1 -> RIGHT");
+eq(G.step_orientation(G.STEM_DOWN, -1), G.LEFT_DOWN, "middle -1 -> LEFT");
+eq(G.step_orientation(G.RIGHT_DOWN, 1), G.RIGHT_DOWN, "RIGHT end +1 -> stays RIGHT (clamped)");
+eq(G.step_orientation(G.RIGHT_DOWN, -1), G.STEM_DOWN, "RIGHT end -1 -> back to STEM");
+eq(G.step_orientation(G.LEFT_DOWN, -1), G.LEFT_DOWN, "LEFT end -1 -> stays LEFT (clamped)");
+eq(G.step_orientation(G.LEFT_DOWN, 1), G.STEM_DOWN, "LEFT end +1 -> back to STEM");
+{
+  // end arms can't cross directly: from RIGHT, a +1 turn must be a no-op
+  const g = new Game(7);
+  g.rotate_field(1);                                   // STEM -> RIGHT
+  eq(g.board.orientation, G.RIGHT_DOWN, "turned to RIGHT end");
+  const before = g.piece;
+  g.events.length = 0;
+  g.rotate_field(1);                                   // try to cross to the other end
+  eq(g.board.orientation, G.RIGHT_DOWN, "stays at RIGHT (no cross-flip)");
+  ok(!g.events.includes("turn"), "no turn event when clamped");
+  ok(g.piece === before, "piece untouched when clamped");
+}
+
+// --- movement not inverted ---------------------------------------------------
+{
+  const g = new Game(3);
+  eq(g.board.orientation, G.STEM_DOWN, "seed 3 starts STEM_DOWN");
+  const x0 = g.piece.x;
+  g.move_left();
+  eq(g.piece.x, x0 - 1, "move_left is screen-left (-x) stem-down");
+  g.move_right(); g.move_right();
+  eq(g.piece.x, x0 + 1, "move_right is screen-right (+x) stem-down");
+}
+
+// --- field rotation preserves depth + round-trips ---------------------------
+function pieceDepth(g) {
+  const arm = G.DOWN_ARM[g.board.orientation];
+  return Math.min(...g.piece.cells().map(([x, y]) => G.to_local(x, y, arm)[1]));
+}
+{
+  const g = new Game(5);
+  for (let i = 0; i < 12; i++) g.tick_gravity();
+  const depth0 = pieceDepth(g);
+  ok(depth0 > 0, "piece dropped into the stem");
+  for (const step of [1, -1, 1, 1, -1, 1]) g.rotate_field(step);
+  ok(pieceDepth(g) >= depth0, "rotation never lifts the piece (anti-hover)");
+}
+{
+  const g = new Game(9);
+  for (let i = 0; i < 6; i++) g.tick_gravity();
+  const before = new Set(g.piece.cells().map(([x, y]) => key(x, y)));
+  const o = g.board.orientation;
+  g.rotate_field(1); g.rotate_field(-1);
+  eq(g.board.orientation, o, "orientation restored after round-trip");
+  const after = new Set(g.piece.cells().map(([x, y]) => key(x, y)));
+  ok(before.size === after.size && [...before].every(k => after.has(k)),
+     "piece cells restored after rotation round-trip");
+}
+
+// --- sound events ------------------------------------------------------------
+{
+  const g = new Game(3);
+  g.events.length = 0; g.move_left(); ok(g.events.includes("move"), "move emits 'move'");
+  g.events.length = 0; g.rotate_field(1); ok(g.events.includes("turn"), "rotate_field emits 'turn'");
+  g.events.length = 0; g.rotate_piece(); ok(g.events.includes("rotate"), "rotate_piece emits 'rotate'");
+  const g2 = new Game(1);
+  g2.events.length = 0; g2.hard_drop(); ok(g2.events.includes("lock"), "hard_drop emits 'lock'");
+}
+
+// --- report ------------------------------------------------------------------
+if (fails.length) {
+  console.error(`\n✗ ${fails.length} FAILED (${passed} passed):`);
+  for (const f of fails) console.error("  -", f);
+  process.exit(1);
+} else {
+  console.log(`✓ all ${passed} parity assertions passed`);
+}

--- a/personal/TopNav.jsx
+++ b/personal/TopNav.jsx
@@ -17,6 +17,7 @@ function TopNav({ route, onNavigate, plain, onPlain, hasWriting, hasNotebook, ha
              className={route === it.id ? "active" : ""}
              onClick={() => onNavigate(it.id)}>{it.label}</a>
         ))}
+        <a href="../fun/">Fun ↗</a>
       </div>
       <div className="right">
         <button className="plain-toggle" onClick={onPlain} aria-pressed={plain} title="Plain text view">▢ plain</button>

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -245,7 +245,7 @@ async function main() {
   log(`snapshot: ${repos.length} repos, ${stats.length} stat tiles`);
 
   // 3. copy served tree
-  for (const item of ["assets", "shared", "dev", "personal", "posts", "acknowledgements"]) {
+  for (const item of ["assets", "shared", "dev", "personal", "posts", "acknowledgements", "fun"]) {
     if (existsSync(join(REPO, item))) cpSync(join(REPO, item), join(OUT, item), { recursive: true });
   }
   for (const f of ["index.html", ".nojekyll"]) {


### PR DESCRIPTION
Adds a **neal.fun-style "Fun" section** to the site, with a browser-native port of **Tritris** as the first toy. Linked from the **personal side only**.

## What's here

**`/fun/` landing** (`fun/index.html`)
- Minimal wall of toys in the personal (paper) theme: just the "Fun" title over thumbnail tiles.
- Tritris tile uses a hand-drawn SVG (`fun/assets/tritris.svg`) and links through to the game; two "coming soon" placeholders.

**`/fun/tritris/` — native HTML5 game** (no pygbag/WASM, a real JS rewrite)
- `engine.js` — faithful JS port of the Python game's pure logic (config / pieces / geometry / board / game), including the new **linear `left–stem–right` field rotation** (no jarring end-to-end flip).
- `main.js` — canvas renderer with the animated rotating-T view + a **zoomed single-arm view** (fills the frame at ~the desktop game's cell size) + minimap, keyboard **and** touch controls, and a **WebAudio** chiptune port of the SFX table.
- `test.mjs` — Node parity check mirroring the Python `test_logic.py` (**3069 assertions**; pruned from the published build since the site drops `.mjs`).

**Integration**
- `scripts/build.mjs` — `/fun/` ships by adding `"fun"` to the copy allowlist.
- `personal/TopNav.jsx` — a `Fun ↗` nav link (personal side only; dev nav / root splash untouched).

## Verified
Built + served locally and driven in the browser: nav → Fun → game click-through, full + zoomed views, field rotation (keyboard + touch) incl. the end-arm clamp, per-arm stacks, mobile touch layout, and a clean console. The companion Python change is in arslankazmi/tritris#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)